### PR TITLE
feature/code-clean-up

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpunit.xml.dist export-ignore
+/php_cs.dist

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 /composer.lock
 /phpunit.xml
+/.php_cs

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,63 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->notPath('bootstrap/cache')
+    ->notPath('storage')
+    ->notPath('vendor')
+    ->in(__DIR__)
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return PhpCsFixer\Config::create()
+    ->setUsingCache(false)
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        'psr4' => true,
+        'binary_operator_spaces' => false,
+        'array_syntax' => ['syntax' => 'short'],
+        'linebreak_after_opening_tag' => true,
+        'not_operator_with_successor_space' => true,
+        'no_unused_imports' => true,
+        'not_operator_with_successor_space' => false,
+        'object_operator_without_whitespace' => true,
+        'ordered_imports' => true,
+        'phpdoc_order' => true,
+        'blank_line_before_return' => true,
+        'single_quote' => true,
+        'blank_line_after_opening_tag' => true,
+        'no_extra_blank_lines' => [
+            'extra',
+            'continue',
+            'curly_brace_block',
+            'parenthesis_brace_block',
+            'return',
+            'square_brace_block',
+            'throw',
+            'use',
+            'use_trait',
+            'switch',
+            'case',
+            'default',
+        ],
+        'no_whitespace_in_blank_line' => true,
+        'no_blank_lines_after_class_opening' => true,
+        'return_type_declaration' => [
+            'space_before' => 'none',
+        ],
+        'concat_space' => [
+            'spacing' => 'one',
+        ],
+        'compact_nullable_typehint' => true,
+        'ternary_operator_spaces' => true,
+        'unary_operator_spaces' => true,
+        'binary_operator_spaces' => [
+            'default' => 'single_space',
+            'operators' => [
+                '|' => 'no_space',
+            ]
+        ]
+    ])
+    ->setFinder($finder);

--- a/classes/exception/DeadlineException.php
+++ b/classes/exception/DeadlineException.php
@@ -1,8 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\exception;
 
-class DeadlineException extends \Exception
-{
+use RuntimeException;
 
+/**
+ * A deadline exception.
+ *
+ * @author Willem Stuursma-Ruwen <willem@stuursma.name>
+ * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations
+ * @license WTFPL
+ */
+class DeadlineException extends RuntimeException implements PhpLockException
+{
 }

--- a/classes/exception/DeadlineException.php
+++ b/classes/exception/DeadlineException.php
@@ -7,7 +7,7 @@ namespace malkusch\lock\exception;
 use RuntimeException;
 
 /**
- * A deadline exception.
+ * Deadline exception.
  *
  * @author Willem Stuursma-Ruwen <willem@stuursma.name>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations

--- a/classes/exception/ExecutionOutsideLockException.php
+++ b/classes/exception/ExecutionOutsideLockException.php
@@ -5,16 +5,18 @@ declare(strict_types=1);
 namespace malkusch\lock\exception;
 
 /**
- * Synchronized code has been executed outside of the lock exception.
+ * Execution outside lock exception.
  *
  * This exception should be thrown when for example the lock is released or the
- * lock times out before the synchronized code finished execution.
+ * lock times out before the critical code has finished execution. This is a
+ * serious exception. Side effects might have happened while the critical code
+ * was executed outside of the lock which should not be trusted to be valid.
  *
  * Should only be used in contexts where the is being released.
  *
  * @see \malkusch\lock\mutex\SpinlockMutex::unlock()
  *
- * @author  Petr Levtonov <petr@levtonov.com>
+ * @author Petr Levtonov <petr@levtonov.com>
  * @license WTFPL
  */
 class ExecutionOutsideLockException extends LockReleaseException
@@ -22,11 +24,10 @@ class ExecutionOutsideLockException extends LockReleaseException
     /**
      * Creates a new instance of the ExecutionOutsideLockException class.
      *
-     * @param  float $elapsedTime Total elapsed time of the synchronized code
-     *         callback execution.
-     * @param  int   $timeout     The lock timeout in seconds.
-     * @return self Synchronized code has been executed outside of the lock
-     *         exception.
+     * @param float $elapsedTime Total elapsed time of the synchronized code
+     * callback execution.
+     * @param int $timeout The lock timeout in seconds.
+     * @return self Execution outside lock exception.
      */
     public static function create(float $elapsedTime, int $timeout): self
     {

--- a/classes/exception/ExecutionOutsideLockException.php
+++ b/classes/exception/ExecutionOutsideLockException.php
@@ -1,28 +1,41 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\exception;
 
 /**
- * This exception should be thrown when for example the lock is released or
- * times out before the synchronized code finished execution.
+ * Synchronized code has been executed outside of the lock exception.
+ *
+ * This exception should be thrown when for example the lock is released or the
+ * lock times out before the synchronized code finished execution.
+ *
+ * Should only be used in contexts where the is being released.
  *
  * @see \malkusch\lock\mutex\SpinlockMutex::unlock()
  *
- * @author Petr Levtonov <petr@levtonov.com>
+ * @author  Petr Levtonov <petr@levtonov.com>
  * @license WTFPL
  */
 class ExecutionOutsideLockException extends LockReleaseException
 {
-    public static function create($elapsed_time, $timeout)
+    /**
+     * Creates a new instance of the ExecutionOutsideLockException class.
+     *
+     * @param  float $elapsedTime Total elapsed time of the synchronized code
+     *         callback execution.
+     * @param  int   $timeout     The lock timeout in seconds.
+     * @return self Synchronized code has been executed outside of the lock
+     *         exception.
+     */
+    public static function create(float $elapsedTime, int $timeout): self
     {
-        $message = sprintf(
-            "The code executed for %.2F seconds. But the timeout is %d " .
-            "seconds. The last %.2F seconds were executed outside the lock.",
-            $elapsed_time,
+        return new self(\sprintf(
+            'The code executed for %.2F seconds. But the timeout is %d ' .
+            'seconds. The last %.2F seconds were executed outside of the lock.',
+            $elapsedTime,
             $timeout,
-            $elapsed_time - $timeout
-        );
-
-        return new self($message);
+            $elapsedTime - $timeout
+        ));
     }
 }

--- a/classes/exception/LockAcquireException.php
+++ b/classes/exception/LockAcquireException.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace malkusch\lock\exception;
 
 /**
- * Failed to acquire lock.
+ * Lock acquire exception.
  *
- * This exception implies that the critical code was not executed, or at least
- * had no side effects.
+ * Used when the lock could not be acquired. This exception implies that the
+ * critical code was not executed, or at least had no side effects.
  *
  * @author Markus Malkusch <markus@malkusch.de>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations

--- a/classes/exception/LockAcquireException.php
+++ b/classes/exception/LockAcquireException.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\exception;
 
 /**
  * Failed to acquire lock.
  *
- * This exception implies that the critical code was not executed, or at
- * least had no side effects.
+ * This exception implies that the critical code was not executed, or at least
+ * had no side effects.
  *
  * @author Markus Malkusch <markus@malkusch.de>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations
@@ -14,5 +16,4 @@ namespace malkusch\lock\exception;
  */
 class LockAcquireException extends MutexException
 {
-
 }

--- a/classes/exception/LockReleaseException.php
+++ b/classes/exception/LockReleaseException.php
@@ -1,13 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\exception;
 
+use Throwable;
+
 /**
- * Failed to release lock.
+ * Failed to release the lock.
  *
- * Take this exception very serious. Failing to release a lock might have
- * the potential to introduce deadlocks. Also the critical code was executed
- * i.e. side effects may have happened.
+ * Take this exception very serious. Failing to release a lock might have the
+ * potential to introduce deadlocks. Also the critical code was executed i.e.
+ * side effects may have happened.
  *
  * @author Markus Malkusch <markus@malkusch.de>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations
@@ -15,46 +19,68 @@ namespace malkusch\lock\exception;
  */
 class LockReleaseException extends MutexException
 {
-
     /**
+     * Result that has been returned during the synchronized code execution.
+     *
      * @var mixed
      */
-    private $code_result;
+    private $codeResult;
 
     /**
+     * Exception that has happened during the synchronized code execution.
+     *
      * @var \Throwable|null
      */
-    private $code_exception;
+    private $codeException;
 
     /**
+     * Gets the result that has been returned during the synchronized code
+     * execution.
+     *
      * @return mixed The return value of the executed code block.
      */
     public function getCodeResult()
     {
-        return $this->code_result;
+        return $this->codeResult;
     }
 
     /**
-     * @param mixed $code_result The return value of the executed code block.
+     * Sets the result that has been returned during the synchronized code
+     * execution.
+     *
+     * @param mixed $codeResult The return value of the executed code block.
+     * @return self Current lock release exception instance.
      */
-    public function setCodeResult($code_result): void
+    public function setCodeResult($codeResult): self
     {
-        $this->code_result = $code_result;
+        $this->codeResult = $codeResult;
+
+        return $this;
     }
 
     /**
-     * @return \Throwable|null The exception thrown by the code block or null when there was no exception.
+     * Gets the exception that has happened during the synchronized code
+     * execution.
+     *
+     * @return \Throwable|null The exception thrown by the code block or null
+     *         when there was no exception.
      */
-    public function getCodeException(): ?\Throwable
+    public function getCodeException(): ?Throwable
     {
-        return $this->code_exception;
+        return $this->codeException;
     }
 
     /**
-     * @param \Throwable $code_exception The exception thrown by the code block.
+     * Sets the exception that has happened during the synchronized code
+     * execution.
+     *
+     * @param \Throwable $codeException The exception thrown by the code block.
+     * @return self Current lock release exception instance.
      */
-    public function setCodeException(\Throwable $code_exception): void
+    public function setCodeException(Throwable $codeException): self
     {
-        $this->code_exception = $code_exception;
+        $this->codeException = $codeException;
+
+        return $this;
     }
 }

--- a/classes/exception/LockReleaseException.php
+++ b/classes/exception/LockReleaseException.php
@@ -7,11 +7,11 @@ namespace malkusch\lock\exception;
 use Throwable;
 
 /**
- * Failed to release the lock.
+ * Lock release exception.
  *
- * Take this exception very serious. Failing to release a lock might have the
- * potential to introduce deadlocks. Also the critical code was executed i.e.
- * side effects may have happened.
+ * Failed to release the lock. Take this exception very serious. Failing to
+ * release a lock might have the potential to introduce deadlocks. Also the
+ * critical code was executed i.e. side effects may have happened.
  *
  * @author Markus Malkusch <markus@malkusch.de>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations
@@ -20,21 +20,21 @@ use Throwable;
 class LockReleaseException extends MutexException
 {
     /**
-     * Result that has been returned during the synchronized code execution.
+     * Result that has been returned during the critical code execution.
      *
      * @var mixed
      */
     private $codeResult;
 
     /**
-     * Exception that has happened during the synchronized code execution.
+     * Exception that has happened during the critical code execution.
      *
      * @var \Throwable|null
      */
     private $codeException;
 
     /**
-     * Gets the result that has been returned during the synchronized code
+     * Gets the result that has been returned during the critical code
      * execution.
      *
      * @return mixed The return value of the executed code block.
@@ -45,7 +45,7 @@ class LockReleaseException extends MutexException
     }
 
     /**
-     * Sets the result that has been returned during the synchronized code
+     * Sets the result that has been returned during the critical code
      * execution.
      *
      * @param mixed $codeResult The return value of the executed code block.
@@ -63,7 +63,7 @@ class LockReleaseException extends MutexException
      * execution.
      *
      * @return \Throwable|null The exception thrown by the code block or null
-     *         when there was no exception.
+     * when there has been no exception.
      */
     public function getCodeException(): ?Throwable
     {
@@ -71,7 +71,7 @@ class LockReleaseException extends MutexException
     }
 
     /**
-     * Sets the exception that has happened during the synchronized code
+     * Sets the exception that has happened during the critical code
      * execution.
      *
      * @param \Throwable $codeException The exception thrown by the code block.

--- a/classes/exception/MutexException.php
+++ b/classes/exception/MutexException.php
@@ -1,16 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\exception;
 
+use RuntimeException;
+
 /**
- * A Mutex exception.
+ * A mutex exception.
  *
  * @author Markus Malkusch <markus@malkusch.de>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations
  * @license WTFPL
  */
-class MutexException extends \Exception
+class MutexException extends RuntimeException implements PhpLockException
 {
-
-    const REDIS_NOT_ENOUGH_SERVERS = 1;
+    /**
+     * @var int Not enough redis servers.
+     */
+    public const REDIS_NOT_ENOUGH_SERVERS = 1;
 }

--- a/classes/exception/MutexException.php
+++ b/classes/exception/MutexException.php
@@ -7,7 +7,10 @@ namespace malkusch\lock\exception;
 use RuntimeException;
 
 /**
- * A mutex exception.
+ * Mutex exception.
+ *
+ * Generic exception for any other not covered reason. Usually extended by
+ * child classes.
  *
  * @author Markus Malkusch <markus@malkusch.de>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations

--- a/classes/exception/PhpLockException.php
+++ b/classes/exception/PhpLockException.php
@@ -7,7 +7,7 @@ namespace malkusch\lock\exception;
 /**
  * Common php-lock/lock exception interface.
  *
- * @author  Petr Levtonov <petr@levtonov.com>
+ * @author Petr Levtonov <petr@levtonov.com>
  * @license WTFPL
  *
  * @method string getMessage()

--- a/classes/exception/PhpLockException.php
+++ b/classes/exception/PhpLockException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace malkusch\lock\exception;
+
+/**
+ * Common php-lock/lock exception interface.
+ *
+ * @author  Petr Levtonov <petr@levtonov.com>
+ * @license WTFPL
+ *
+ * @method string getMessage()
+ * @method int getCode()
+ * @method string getFile()
+ * @method int getLine()
+ * @method array getTrace()
+ * @method string getTraceAsString()
+ * @method \Throwable|null getPrevious()
+ * @method string __toString()
+ */
+interface PhpLockException
+{
+}

--- a/classes/exception/TimeoutException.php
+++ b/classes/exception/TimeoutException.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace malkusch\lock\exception;
 
 /**
- * A timeout has been exceeded exception.
+ * Timeout exception.
  *
- * Should only be used in contexts where the lock is being acquired.
+ * A timeout has been exceeded exception. Should only be used in contexts where
+ * the lock is being acquired.
  *
  * @author Markus Malkusch <markus@malkusch.de>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations
@@ -18,7 +19,7 @@ class TimeoutException extends LockAcquireException
     /**
      * Creates a new instance of the TimeoutException class.
      *
-     * @param  int $timeout The timeout in seconds.
+     * @param int $timeout The timeout in seconds.
      * @return self A timeout has been exceeded exception.
      */
     public static function create(int $timeout): self

--- a/classes/exception/TimeoutException.php
+++ b/classes/exception/TimeoutException.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\exception;
 
 /**
- * A timeout was exceeded.
+ * A timeout has been exceeded exception.
+ *
+ * Should only be used in contexts where the lock is being acquired.
  *
  * @author Markus Malkusch <markus@malkusch.de>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations
@@ -12,11 +16,13 @@ namespace malkusch\lock\exception;
 class TimeoutException extends LockAcquireException
 {
     /**
-     * @param int $timeout
-     * @return TimeoutException
+     * Creates a new instance of the TimeoutException class.
+     *
+     * @param  int $timeout The timeout in seconds.
+     * @return self A timeout has been exceeded exception.
      */
-    public static function create($timeout)
+    public static function create(int $timeout): self
     {
-        return new self(sprintf("Timeout of %d seconds exceeded.", $timeout));
+        return new self(\sprintf('Timeout of %d seconds exceeded.', $timeout));
     }
 }

--- a/classes/mutex/CASMutex.php
+++ b/classes/mutex/CASMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use malkusch\lock\exception\TimeoutException;

--- a/classes/mutex/CASMutex.php
+++ b/classes/mutex/CASMutex.php
@@ -19,12 +19,11 @@ use malkusch\lock\util\Loop;
  */
 class CASMutex extends Mutex
 {
-    
     /**
      * @var Loop The loop.
      */
     private $loop;
-    
+
     /**
      * Sets the timeout.
      *
@@ -37,7 +36,7 @@ class CASMutex extends Mutex
     {
         $this->loop = new Loop($timeout);
     }
-    
+
     /**
      * Notifies the Mutex about a successful CAS operation.
      */
@@ -45,7 +44,7 @@ class CASMutex extends Mutex
     {
         $this->loop->end();
     }
-    
+
     /**
      * Repeats executing a code until a compare-and-swap operation was successful.
      *
@@ -72,10 +71,10 @@ class CASMutex extends Mutex
      * </code>
      *
      * @param callable $code The synchronized execution block.
-     * @return mixed The return value of the execution block.
-     *
      * @throws \Exception The execution block threw an exception.
      * @throws TimeoutException The timeout was reached.
+     * @return mixed The return value of the execution block.
+     *
      */
     public function synchronized(callable $code)
     {

--- a/classes/mutex/FlockMutex.php
+++ b/classes/mutex/FlockMutex.php
@@ -3,7 +3,6 @@
 namespace malkusch\lock\mutex;
 
 use malkusch\lock\exception\DeadlineException;
-use malkusch\lock\exception\ExecutionOutsideLockException;
 use malkusch\lock\exception\LockAcquireException;
 use malkusch\lock\exception\LockReleaseException;
 use malkusch\lock\exception\TimeoutException;
@@ -35,7 +34,7 @@ class FlockMutex extends LockMutex
     /**
      * @internal
      */
-    const STRATEGY_BUSY  = 3;
+    const STRATEGY_BUSY = 3;
 
     /**
      * @var resource $fileHandle The file handle.
@@ -61,12 +60,12 @@ class FlockMutex extends LockMutex
     public function __construct($fileHandle, int $timeout = self::INFINITE_TIMEOUT)
     {
         if (!is_resource($fileHandle)) {
-            throw new \InvalidArgumentException("The file handle is not a valid resource.");
+            throw new \InvalidArgumentException('The file handle is not a valid resource.');
         }
 
         $this->fileHandle = $fileHandle;
-        $this->timeout    = $timeout;
-        $this->strategy   = $this->determineLockingStrategy();
+        $this->timeout = $timeout;
+        $this->strategy = $this->determineLockingStrategy();
     }
 
     private function determineLockingStrategy()
@@ -88,7 +87,7 @@ class FlockMutex extends LockMutex
     private function lockBlocking(): void
     {
         if (!flock($this->fileHandle, LOCK_EX)) {
-            throw new LockAcquireException("Failed to lock the file.");
+            throw new LockAcquireException('Failed to lock the file.');
         }
     }
 
@@ -126,20 +125,21 @@ class FlockMutex extends LockMutex
     }
 
     /**
-     * @return bool
      * @throws LockAcquireException
+     * @return bool
      */
     private function acquireNonBlockingLock(): bool
     {
-        if (!flock($this->fileHandle, LOCK_EX | LOCK_NB, $wouldBlock)) {
+        if (!flock($this->fileHandle, LOCK_EX|LOCK_NB, $wouldBlock)) {
             if ($wouldBlock) {
                 /*
                  * Another process holds the lock.
                  */
                 return false;
             }
-            throw new LockAcquireException("Failed to lock the file.");
+            throw new LockAcquireException('Failed to lock the file.');
         }
+
         return true;
     }
 
@@ -152,12 +152,15 @@ class FlockMutex extends LockMutex
         switch ($this->strategy) {
             case self::STRATEGY_BLOCK:
                 $this->lockBlocking();
+
                 return;
             case self::STRATEGY_PCNTL:
                 $this->lockPcntl();
+
                 return;
             case self::STRATEGY_BUSY:
                 $this->lockBusy();
+
                 return;
         }
 
@@ -170,7 +173,7 @@ class FlockMutex extends LockMutex
     protected function unlock(): void
     {
         if (!flock($this->fileHandle, LOCK_UN)) {
-            throw new LockReleaseException("Failed to unlock the file.");
+            throw new LockReleaseException('Failed to unlock the file.');
         }
     }
 }

--- a/classes/mutex/FlockMutex.php
+++ b/classes/mutex/FlockMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use malkusch\lock\exception\DeadlineException;

--- a/classes/mutex/LockMutex.php
+++ b/classes/mutex/LockMutex.php
@@ -23,7 +23,7 @@ abstract class LockMutex extends Mutex
      * This method blocks until the lock was acquired.
      *
      * @throws \malkusch\lock\exception\LockAcquireException The lock could not
-     *         be acquired.
+     * be acquired.
      */
     abstract protected function lock(): void;
 
@@ -31,7 +31,7 @@ abstract class LockMutex extends Mutex
      * Releases the lock.
      *
      * @throws \malkusch\lock\exception\LockReleaseException The lock could not
-     *         be released.
+     * be released.
      */
     abstract protected function unlock(): void;
 

--- a/classes/mutex/LockMutex.php
+++ b/classes/mutex/LockMutex.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
-use malkusch\lock\exception\LockAcquireException;
 use malkusch\lock\exception\LockReleaseException;
+use Throwable;
 
 /**
  * Locking mutex.
@@ -15,48 +17,52 @@ use malkusch\lock\exception\LockReleaseException;
  */
 abstract class LockMutex extends Mutex
 {
-
     /**
      * Acquires the lock.
      *
      * This method blocks until the lock was acquired.
      *
-     * @throws LockAcquireException The lock could not be acquired.
+     * @throws \malkusch\lock\exception\LockAcquireException The lock could not
+     *         be acquired.
      */
     abstract protected function lock(): void;
 
     /**
      * Releases the lock.
      *
-     * @throws LockReleaseException The lock could not be released.
+     * @throws \malkusch\lock\exception\LockReleaseException The lock could not
+     *         be released.
      */
     abstract protected function unlock(): void;
 
+    /**
+     * {@inheritDoc}
+     */
     public function synchronized(callable $code)
     {
         $this->lock();
 
-        $code_result = null;
-        $code_exception = null;
+        $codeResult = null;
+        $codeException = null;
         try {
-            $code_result = $code();
-        } catch (\Throwable $exception) {
-            $code_exception = $exception;
+            $codeResult = $code();
+        } catch (Throwable $exception) {
+            $codeException = $exception;
 
             throw $exception;
         } finally {
             try {
                 $this->unlock();
-            } catch (LockReleaseException $lock_exception) {
-                $lock_exception->setCodeResult($code_result);
-                if ($code_exception !== null) {
-                    $lock_exception->setCodeException($code_exception);
+            } catch (LockReleaseException $lockReleaseException) {
+                $lockReleaseException->setCodeResult($codeResult);
+                if ($codeException !== null) {
+                    $lockReleaseException->setCodeException($codeException);
                 }
 
-                throw $lock_exception;
+                throw $lockReleaseException;
             }
         }
 
-        return $code_result;
+        return $codeResult;
     }
 }

--- a/classes/mutex/MemcachedMutex.php
+++ b/classes/mutex/MemcachedMutex.php
@@ -13,12 +13,11 @@ use Memcached;
  */
 class MemcachedMutex extends SpinlockMutex
 {
-    
     /**
      * @var Memcached The connected Memcached API.
      */
     private $memcache;
-    
+
     /**
      * Sets the lock's name and the connected Memcached API.
      *
@@ -34,7 +33,7 @@ class MemcachedMutex extends SpinlockMutex
     public function __construct(string $name, Memcached $memcache, int $timeout = 3)
     {
         parent::__construct($name, $timeout);
-        
+
         $this->memcache = $memcache;
     }
 

--- a/classes/mutex/MemcachedMutex.php
+++ b/classes/mutex/MemcachedMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use Memcached;

--- a/classes/mutex/Mutex.php
+++ b/classes/mutex/Mutex.php
@@ -25,16 +25,15 @@ abstract class Mutex
      * The code block may throw an exception. In this case the lock will be
      * released as well.
      *
-     * @param  callable $code The synchronized execution callback.
+     * @param callable $code The synchronized execution callback.
      * @throws \Exception The execution callback threw an exception.
      * @throws \malkusch\lock\exception\LockAcquireException The mutex could not
-     *         be acquired, no further side effects.
+     * be acquired, no further side effects.
      * @throws \malkusch\lock\exception\LockReleaseException The mutex could not
-     *         be released, the code was already executed.
+     * be released, the code was already executed.
      * @throws \malkusch\lock\exception\ExecutionOutsideLockException Some code
-     *         has been executed outside of the lock.
+     * has been executed outside of the lock.
      * @return mixed The return value of the execution callback.
-     *
      */
     abstract public function synchronized(callable $code);
 
@@ -53,11 +52,11 @@ abstract class Mutex
      * });
      * </code>
      *
-     * @param  callable $check Callback that decides if the lock should be
-     *         acquired and if the synchronized callback should be executed
-     *         after acquiring the lock.
+     * @param callable $check Callback that decides if the lock should be
+     * acquired and if the synchronized callback should be executed after
+     * acquiring the lock.
      * @return \malkusch\lock\util\DoubleCheckedLocking The double-checked
-     *         locking pattern.
+     * locking pattern.
      */
     public function check(callable $check): DoubleCheckedLocking
     {

--- a/classes/mutex/Mutex.php
+++ b/classes/mutex/Mutex.php
@@ -26,8 +26,6 @@ abstract class Mutex
      * released as well.
      *
      * @param  callable $code The synchronized execution callback.
-     * @return mixed The return value of the execution callback.
-     *
      * @throws \Exception The execution callback threw an exception.
      * @throws \malkusch\lock\exception\LockAcquireException The mutex could not
      *         be acquired, no further side effects.
@@ -35,6 +33,8 @@ abstract class Mutex
      *         be released, the code was already executed.
      * @throws \malkusch\lock\exception\ExecutionOutsideLockException Some code
      *         has been executed outside of the lock.
+     * @return mixed The return value of the execution callback.
+     *
      */
     abstract public function synchronized(callable $code);
 

--- a/classes/mutex/Mutex.php
+++ b/classes/mutex/Mutex.php
@@ -1,10 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
-use malkusch\lock\exception\ExecutionOutsideLockException;
-use malkusch\lock\exception\LockAcquireException;
-use malkusch\lock\exception\LockReleaseException;
 use malkusch\lock\util\DoubleCheckedLocking;
 
 /**
@@ -16,7 +15,6 @@ use malkusch\lock\util\DoubleCheckedLocking;
  */
 abstract class Mutex
 {
-    
     /**
      * Executes a block of code exclusively.
      *
@@ -27,32 +25,39 @@ abstract class Mutex
      * The code block may throw an exception. In this case the lock will be
      * released as well.
      *
-     * @param callable $code The synchronized execution block.
-     * @return mixed The return value of the execution block.
+     * @param  callable $code The synchronized execution callback.
+     * @return mixed The return value of the execution callback.
      *
-     * @throws \Exception The execution block threw an exception.
-     * @throws LockAcquireException The mutex could not be acquired, no further side effects.
-     * @throws LockReleaseException The mutex could not be released, the code was already executed.
-     * @throws ExecutionOutsideLockException Some code was executed outside of the lock.
+     * @throws \Exception The execution callback threw an exception.
+     * @throws \malkusch\lock\exception\LockAcquireException The mutex could not
+     *         be acquired, no further side effects.
+     * @throws \malkusch\lock\exception\LockReleaseException The mutex could not
+     *         be released, the code was already executed.
+     * @throws \malkusch\lock\exception\ExecutionOutsideLockException Some code
+     *         has been executed outside of the lock.
      */
     abstract public function synchronized(callable $code);
-    
+
     /**
      * Performs a double-checked locking pattern.
      *
-     * Call {@link DoubleCheckedLocking::then()} on the returned object.
+     * Call {@link \malkusch\lock\util\DoubleCheckedLocking::then()} on the
+     * returned object.
      *
      * Example:
      * <code>
-     * $mutex->check(function () use ($bankAccount, $amount) {
+     * $result = $mutex->check(function () use ($bankAccount, $amount) {
      *     return $bankAccount->getBalance() >= $amount;
-     *
      * })->then(function () use ($bankAccount, $amount) {
-     *     $bankAccount->withdraw($amount);
+     *     return $bankAccount->withdraw($amount);
      * });
      * </code>
      *
-     * @return DoubleCheckedLocking The double-checked locking pattern.
+     * @param  callable $check Callback that decides if the lock should be
+     *         acquired and if the synchronized callback should be executed
+     *         after acquiring the lock.
+     * @return \malkusch\lock\util\DoubleCheckedLocking The double-checked
+     *         locking pattern.
      */
     public function check(callable $check): DoubleCheckedLocking
     {

--- a/classes/mutex/MySQLMutex.php
+++ b/classes/mutex/MySQLMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use InvalidArgumentException;

--- a/classes/mutex/MySQLMutex.php
+++ b/classes/mutex/MySQLMutex.php
@@ -2,6 +2,7 @@
 
 namespace malkusch\lock\mutex;
 
+use InvalidArgumentException;
 use malkusch\lock\exception\LockAcquireException;
 use malkusch\lock\exception\TimeoutException;
 
@@ -26,7 +27,7 @@ class MySQLMutex extends LockMutex
         $this->pdo = $PDO;
 
         if (\strlen($name) > 64) {
-            throw new \InvalidArgumentException('The maximum length of the lock name is 64 characters.');
+            throw new InvalidArgumentException('The maximum length of the lock name is 64 characters.');
         }
 
         $this->name = $name;

--- a/classes/mutex/MySQLMutex.php
+++ b/classes/mutex/MySQLMutex.php
@@ -26,7 +26,7 @@ class MySQLMutex extends LockMutex
         $this->pdo = $PDO;
 
         if (\strlen($name) > 64) {
-            throw new \InvalidArgumentException("The maximum length of the lock name is 64 characters.");
+            throw new \InvalidArgumentException('The maximum length of the lock name is 64 characters.');
         }
 
         $this->name = $name;
@@ -38,7 +38,7 @@ class MySQLMutex extends LockMutex
      */
     public function lock(): void
     {
-        $statement = $this->pdo->prepare("SELECT GET_LOCK(?,?)");
+        $statement = $this->pdo->prepare('SELECT GET_LOCK(?,?)');
 
         $statement->execute([
             $this->name,
@@ -59,7 +59,7 @@ class MySQLMutex extends LockMutex
             /*
              *  NULL if an error occurred (such as running out of memory or the thread was killed with mysqladmin kill).
              */
-            throw new LockAcquireException("An error occurred while acquiring the lock");
+            throw new LockAcquireException('An error occurred while acquiring the lock');
         }
 
         throw TimeoutException::create($this->timeout);
@@ -67,7 +67,7 @@ class MySQLMutex extends LockMutex
 
     public function unlock(): void
     {
-        $statement = $this->pdo->prepare("DO RELEASE_LOCK(?)");
+        $statement = $this->pdo->prepare('DO RELEASE_LOCK(?)');
         $statement->execute([
             $this->name
         ]);

--- a/classes/mutex/NoMutex.php
+++ b/classes/mutex/NoMutex.php
@@ -14,7 +14,6 @@ namespace malkusch\lock\mutex;
  */
 class NoMutex extends Mutex
 {
-
     public function synchronized(callable $code)
     {
         return $code();

--- a/classes/mutex/NoMutex.php
+++ b/classes/mutex/NoMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 /**

--- a/classes/mutex/PHPRedisMutex.php
+++ b/classes/mutex/PHPRedisMutex.php
@@ -33,10 +33,9 @@ class PHPRedisMutex extends RedisMutex
      * called already.
      *
      * @param array<\Redis|\RedisCluster> $redisAPIs The Redis connections.
-     * @param string                      $name      The lock name.
-     * @param int                         $timeout   The time in seconds a lock expires after.
-     *                                               Default is 3.
-     *
+     * @param string $name The lock name.
+     * @param int $timeout The time in seconds a lock expires after. Default is
+     * 3 seconds.
      * @throws \LengthException The timeout must be greater than 0.
      */
     public function __construct(array $redisAPIs, string $name, int $timeout = 3)
@@ -45,6 +44,7 @@ class PHPRedisMutex extends RedisMutex
     }
 
     /**
+     * @param \Redis|\RedisCluster $redisApi The Redis or RedisCluster connection.
      * @throws LockAcquireException
      */
     protected function add($redisAPI, string $key, string $value, int $expire): bool
@@ -96,7 +96,7 @@ class PHPRedisMutex extends RedisMutex
     /**
      * Determines if lzf compression is enabled for the given connection.
      *
-     * @param  \Redis|\RedisCluster $redis Redis connection.
+     * @param  \Redis|\RedisCluster $redis The Redis or RedisCluster connection.
      * @return bool TRUE if lzf compression is enabled, false otherwise.
      */
     private function hasLzfCompression($redis): bool

--- a/classes/mutex/PHPRedisMutex.php
+++ b/classes/mutex/PHPRedisMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use malkusch\lock\exception\LockAcquireException;

--- a/classes/mutex/PHPRedisMutex.php
+++ b/classes/mutex/PHPRedisMutex.php
@@ -66,7 +66,7 @@ class PHPRedisMutex extends RedisMutex
      */
     protected function evalScript($redis, string $script, int $numkeys, array $arguments)
     {
-        for ($i = $numkeys; $i < \count($arguments); $i++) {
+        for ($i = $numkeys; $i < count($arguments); $i++) {
             /*
              * If a serialization mode such as "php" or "igbinary" is enabled, the arguments must be
              * serialized by us, because phpredis does not do this for the eval command.

--- a/classes/mutex/PHPRedisMutex.php
+++ b/classes/mutex/PHPRedisMutex.php
@@ -47,7 +47,7 @@ class PHPRedisMutex extends RedisMutex
         /** @var \Redis $redisAPI */
         try {
             //  Will set the key, if it doesn't exist, with a ttl of $expire seconds
-            return $redisAPI->set($key, $value, ["nx", "ex" => $expire]);
+            return $redisAPI->set($key, $value, ['nx', 'ex' => $expire]);
         } catch (RedisException $e) {
             $message = sprintf(
                 "Failed to acquire lock for key '%s'",
@@ -90,7 +90,7 @@ class PHPRedisMutex extends RedisMutex
         try {
             return $redis->eval($script, $arguments, $numkeys);
         } catch (RedisException $e) {
-            throw new LockReleaseException("Failed to release lock", 0, $e);
+            throw new LockReleaseException('Failed to release lock', 0, $e);
         }
     }
 }

--- a/classes/mutex/PgAdvisoryLockMutex.php
+++ b/classes/mutex/PgAdvisoryLockMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use RuntimeException;

--- a/classes/mutex/PgAdvisoryLockMutex.php
+++ b/classes/mutex/PgAdvisoryLockMutex.php
@@ -26,21 +26,21 @@ class PgAdvisoryLockMutex extends LockMutex
     {
         $this->pdo = $PDO;
 
-        $hashed_name = hash("sha256", $name, true);
+        $hashed_name = hash('sha256', $name, true);
 
         if (false === $hashed_name) {
-            throw new \RuntimeException("Unable to hash the key, sha256 algorithm is not supported.");
+            throw new \RuntimeException('Unable to hash the key, sha256 algorithm is not supported.');
         }
 
         list($bytes1, $bytes2) = str_split($hashed_name, 4);
 
-        $this->key1 = unpack("i", $bytes1)[1];
-        $this->key2 = unpack("i", $bytes2)[1];
+        $this->key1 = unpack('i', $bytes1)[1];
+        $this->key2 = unpack('i', $bytes2)[1];
     }
 
     public function lock(): void
     {
-        $statement = $this->pdo->prepare("SELECT pg_advisory_lock(?,?)");
+        $statement = $this->pdo->prepare('SELECT pg_advisory_lock(?,?)');
 
         $statement->execute([
             $this->key1,
@@ -50,7 +50,7 @@ class PgAdvisoryLockMutex extends LockMutex
 
     public function unlock(): void
     {
-        $statement = $this->pdo->prepare("SELECT pg_advisory_unlock(?,?)");
+        $statement = $this->pdo->prepare('SELECT pg_advisory_unlock(?,?)');
         $statement->execute([
             $this->key1,
             $this->key2

--- a/classes/mutex/PgAdvisoryLockMutex.php
+++ b/classes/mutex/PgAdvisoryLockMutex.php
@@ -2,6 +2,8 @@
 
 namespace malkusch\lock\mutex;
 
+use RuntimeException;
+
 class PgAdvisoryLockMutex extends LockMutex
 {
     /**
@@ -29,7 +31,7 @@ class PgAdvisoryLockMutex extends LockMutex
         $hashed_name = hash('sha256', $name, true);
 
         if (false === $hashed_name) {
-            throw new \RuntimeException('Unable to hash the key, sha256 algorithm is not supported.');
+            throw new RuntimeException('Unable to hash the key, sha256 algorithm is not supported.');
         }
 
         list($bytes1, $bytes2) = str_split($hashed_name, 4);

--- a/classes/mutex/PredisMutex.php
+++ b/classes/mutex/PredisMutex.php
@@ -2,10 +2,10 @@
 
 namespace malkusch\lock\mutex;
 
-use Predis\ClientInterface;
-use Predis\PredisException;
 use malkusch\lock\exception\LockAcquireException;
 use malkusch\lock\exception\LockReleaseException;
+use Predis\ClientInterface;
+use Predis\PredisException;
 
 /**
  * Mutex based on the Redlock algorithm using the Predis API.
@@ -18,7 +18,6 @@ use malkusch\lock\exception\LockReleaseException;
  */
 class PredisMutex extends RedisMutex
 {
-    
     /**
      * Sets the Redis connections.
      *
@@ -40,7 +39,7 @@ class PredisMutex extends RedisMutex
     {
         /** @var ClientInterface $redisAPI */
         try {
-            return $redisAPI->set($key, $value, "EX", $expire, "NX") !== null;
+            return $redisAPI->set($key, $value, 'EX', $expire, 'NX') !== null;
         } catch (PredisException $e) {
             $message = sprintf(
                 "Failed to acquire lock for key '%s'",
@@ -59,7 +58,7 @@ class PredisMutex extends RedisMutex
         try {
             return $client->eval($script, $numkeys, ...$arguments);
         } catch (PredisException $e) {
-            throw new LockReleaseException("Failed to release lock", 0, $e);
+            throw new LockReleaseException('Failed to release lock', 0, $e);
         }
     }
 }

--- a/classes/mutex/PredisMutex.php
+++ b/classes/mutex/PredisMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use malkusch\lock\exception\LockAcquireException;

--- a/classes/mutex/RedisMutex.php
+++ b/classes/mutex/RedisMutex.php
@@ -2,11 +2,11 @@
 
 namespace malkusch\lock\mutex;
 
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
-use Psr\Log\LoggerAwareInterface;
 use malkusch\lock\exception\LockAcquireException;
 use malkusch\lock\exception\LockReleaseException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Mutex based on the Redlock algorithm.
@@ -19,7 +19,6 @@ use malkusch\lock\exception\LockReleaseException;
  */
 abstract class RedisMutex extends SpinlockMutex implements LoggerAwareInterface
 {
-    
     /**
      * @var string The random value token for key identification.
      */
@@ -77,7 +76,7 @@ abstract class RedisMutex extends SpinlockMutex implements LoggerAwareInterface
         $errored  = 0;
         $this->token = \random_bytes(16);
         $exception   = null;
-        foreach ($this->redisAPIs as $index => $redisAPI) {
+        foreach ($this->redisAPIs as $redisAPI) {
             try {
                 if ($this->add($redisAPI, $key, $this->token, $expire)) {
                     $acquired++;

--- a/classes/mutex/RedisMutex.php
+++ b/classes/mutex/RedisMutex.php
@@ -74,7 +74,7 @@ abstract class RedisMutex extends SpinlockMutex implements LoggerAwareInterface
         // 2.
         $acquired = 0;
         $errored = 0;
-        $this->token = \random_bytes(16);
+        $this->token = random_bytes(16);
         $exception = null;
         foreach ($this->redisAPIs as $index => $redisAPI) {
             try {

--- a/classes/mutex/RedisMutex.php
+++ b/classes/mutex/RedisMutex.php
@@ -76,7 +76,7 @@ abstract class RedisMutex extends SpinlockMutex implements LoggerAwareInterface
         $errored = 0;
         $this->token = \random_bytes(16);
         $exception = null;
-        foreach ($this->redisAPIs as $redisAPI) {
+        foreach ($this->redisAPIs as $index => $redisAPI) {
             try {
                 if ($this->add($redisAPI, $key, $this->token, $expire)) {
                     $acquired++;
@@ -85,6 +85,7 @@ abstract class RedisMutex extends SpinlockMutex implements LoggerAwareInterface
                 // todo if there is only one redis server, throw immediately.
                 $context = [
                     'key' => $key,
+                    'index' => $index,
                     'token' => $this->token,
                     'exception' => $exception
                 ];

--- a/classes/mutex/RedisMutex.php
+++ b/classes/mutex/RedisMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use malkusch\lock\exception\LockAcquireException;

--- a/classes/mutex/SemaphoreMutex.php
+++ b/classes/mutex/SemaphoreMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use InvalidArgumentException;

--- a/classes/mutex/SemaphoreMutex.php
+++ b/classes/mutex/SemaphoreMutex.php
@@ -14,12 +14,11 @@ use malkusch\lock\exception\LockReleaseException;
  */
 class SemaphoreMutex extends LockMutex
 {
-
     /**
      * @var resource The semaphore id.
      */
     private $semaphore;
-    
+
     /**
      * Sets the semaphore id.
      *
@@ -37,18 +36,18 @@ class SemaphoreMutex extends LockMutex
     public function __construct($semaphore)
     {
         if (!is_resource($semaphore)) {
-            throw new \InvalidArgumentException("The semaphore id is not a valid resource.");
+            throw new \InvalidArgumentException('The semaphore id is not a valid resource.');
         }
         $this->semaphore = $semaphore;
     }
-    
+
     /**
      * @internal
      */
     protected function lock(): void
     {
         if (!sem_acquire($this->semaphore)) {
-            throw new LockAcquireException("Failed to acquire the Semaphore.");
+            throw new LockAcquireException('Failed to acquire the Semaphore.');
         }
     }
 
@@ -58,7 +57,7 @@ class SemaphoreMutex extends LockMutex
     protected function unlock(): void
     {
         if (!sem_release($this->semaphore)) {
-            throw new LockReleaseException("Failed to release the Semaphore.");
+            throw new LockReleaseException('Failed to release the Semaphore.');
         }
     }
 }

--- a/classes/mutex/SemaphoreMutex.php
+++ b/classes/mutex/SemaphoreMutex.php
@@ -2,6 +2,7 @@
 
 namespace malkusch\lock\mutex;
 
+use InvalidArgumentException;
 use malkusch\lock\exception\LockAcquireException;
 use malkusch\lock\exception\LockReleaseException;
 
@@ -36,7 +37,7 @@ class SemaphoreMutex extends LockMutex
     public function __construct($semaphore)
     {
         if (!is_resource($semaphore)) {
-            throw new \InvalidArgumentException('The semaphore id is not a valid resource.');
+            throw new InvalidArgumentException('The semaphore id is not a valid resource.');
         }
         $this->semaphore = $semaphore;
     }

--- a/classes/mutex/SpinlockMutex.php
+++ b/classes/mutex/SpinlockMutex.php
@@ -20,7 +20,7 @@ abstract class SpinlockMutex extends LockMutex
     /**
      * The prefix for the lock key.
      */
-    private const PREFIX = "lock_";
+    private const PREFIX = 'lock_';
 
     /**
      * @var int The timeout in seconds a lock may live.
@@ -52,8 +52,8 @@ abstract class SpinlockMutex extends LockMutex
     public function __construct(string $name, int $timeout = 3)
     {
         $this->timeout = $timeout;
-        $this->loop    = new Loop($this->timeout);
-        $this->key     = self::PREFIX . $name;
+        $this->loop = new Loop($this->timeout);
+        $this->key = self::PREFIX . $name;
     }
 
     protected function lock(): void
@@ -86,7 +86,7 @@ abstract class SpinlockMutex extends LockMutex
          * This guarantees that we don't delete a wrong key.
          */
         if (!$this->release($this->key)) {
-            throw new LockReleaseException("Failed to release the lock.");
+            throw new LockReleaseException('Failed to release the lock.');
         }
     }
 
@@ -96,8 +96,8 @@ abstract class SpinlockMutex extends LockMutex
      * @param string $key The lock key.
      * @param int $expire The timeout in seconds when a lock expires.
      *
-     * @return bool True, if the lock could be acquired.
      * @throws LockAcquireException An unexpected error happened.
+     * @return bool True, if the lock could be acquired.
      */
     abstract protected function acquire(string $key, int $expire): bool;
 

--- a/classes/mutex/SpinlockMutex.php
+++ b/classes/mutex/SpinlockMutex.php
@@ -17,32 +17,31 @@ use malkusch\lock\util\Loop;
  */
 abstract class SpinlockMutex extends LockMutex
 {
-    
-    /**
-     * @var int The timeout in seconds a lock may live.
-     */
-    private $timeout;
-    
-    /**
-     * @var Loop The loop.
-     */
-    private $loop;
-    
-    /**
-     * @var string The lock key.
-     */
-    private $key;
-    
-    /**
-     * @var double The timestamp when the lock was acquired.
-     */
-    private $acquired;
-    
     /**
      * The prefix for the lock key.
      */
     private const PREFIX = "lock_";
-    
+
+    /**
+     * @var int The timeout in seconds a lock may live.
+     */
+    private $timeout;
+
+    /**
+     * @var \malkusch\lock\util\Loop The loop.
+     */
+    private $loop;
+
+    /**
+     * @var string The lock key.
+     */
+    private $key;
+
+    /**
+     * @var double The timestamp when the lock was acquired.
+     */
+    private $acquired;
+
     /**
      * Sets the timeout.
      *
@@ -54,14 +53,14 @@ abstract class SpinlockMutex extends LockMutex
     {
         $this->timeout = $timeout;
         $this->loop    = new Loop($this->timeout);
-        $this->key     = self::PREFIX.$name;
+        $this->key     = self::PREFIX . $name;
     }
-    
+
     protected function lock(): void
     {
         $this->loop->execute(function (): void {
             $this->acquired = microtime(true);
-            
+
             /*
              * The expiration time for the lock is increased by one second
              * to ensure that we delete only our keys. This will prevent the
@@ -90,7 +89,7 @@ abstract class SpinlockMutex extends LockMutex
             throw new LockReleaseException("Failed to release the lock.");
         }
     }
-    
+
     /**
      * Tries to acquire a lock.
      *

--- a/classes/mutex/SpinlockMutex.php
+++ b/classes/mutex/SpinlockMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use malkusch\lock\exception\ExecutionOutsideLockException;

--- a/classes/mutex/TransactionalMutex.php
+++ b/classes/mutex/TransactionalMutex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\mutex;
 
 use Exception;

--- a/classes/mutex/TransactionalMutex.php
+++ b/classes/mutex/TransactionalMutex.php
@@ -19,12 +19,11 @@ use malkusch\lock\util\Loop;
  */
 class TransactionalMutex extends Mutex
 {
-    
     /**
      * @var \PDO $pdo The PDO.
      */
     private $pdo;
-    
+
     /**
      * @var Loop The loop.
      */
@@ -47,14 +46,14 @@ class TransactionalMutex extends Mutex
     public function __construct(\PDO $pdo, int $timeout = 3)
     {
         if ($pdo->getAttribute(\PDO::ATTR_ERRMODE) !== \PDO::ERRMODE_EXCEPTION) {
-            throw new \InvalidArgumentException("The pdo must have PDO::ERRMODE_EXCEPTION set.");
+            throw new \InvalidArgumentException('The pdo must have PDO::ERRMODE_EXCEPTION set.');
         }
         self::checkAutocommit($pdo);
 
-        $this->pdo  = $pdo;
+        $this->pdo = $pdo;
         $this->loop = new Loop($timeout);
     }
-    
+
     /**
      * Checks that the AUTOCOMMIT mode is turned off.
      *
@@ -63,15 +62,15 @@ class TransactionalMutex extends Mutex
     private static function checkAutocommit(\PDO $pdo): void
     {
         $vendor = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
-        
+
         // MySQL turns autocommit off during a transaction.
-        if ($vendor == "mysql") {
+        if ($vendor == 'mysql') {
             return;
         }
 
         try {
             if ($pdo->getAttribute(\PDO::ATTR_AUTOCOMMIT)) {
-                throw new \InvalidArgumentException("PDO::ATTR_AUTOCOMMIT should be disabled.");
+                throw new \InvalidArgumentException('PDO::ATTR_AUTOCOMMIT should be disabled.');
             }
         } catch (\PDOException $e) {
             /*
@@ -80,7 +79,7 @@ class TransactionalMutex extends Mutex
              */
         }
     }
-    
+
     /**
      * Executes the critical code within a transaction.
      *
@@ -97,11 +96,11 @@ class TransactionalMutex extends Mutex
      * and won't  be replayed.
      *
      * @param callable $code The synchronized execution block.
+     * @throws \Exception The execution block threw an exception.
+     * @throws LockAcquireException The transaction was not commited.
      * @return mixed The return value of the execution block.
      * @SuppressWarnings(PHPMD)
      *
-     * @throws \Exception The execution block threw an exception.
-     * @throws LockAcquireException The transaction was not commited.
      */
     public function synchronized(callable $code)
     {
@@ -110,18 +109,19 @@ class TransactionalMutex extends Mutex
                 // BEGIN
                 $this->pdo->beginTransaction();
             } catch (\PDOException $e) {
-                throw new LockAcquireException("Could not begin transaction.", 0, $e);
+                throw new LockAcquireException('Could not begin transaction.', 0, $e);
             }
-            
+
             try {
                 // Unit of work
                 $result = $code();
                 $this->pdo->commit();
                 $this->loop->end();
+
                 return $result;
             } catch (\Exception $e) {
                 $this->rollBack($e);
-                
+
                 if (self::hasPDOException($e)) {
                     return; // Replay
                 } else {
@@ -130,7 +130,7 @@ class TransactionalMutex extends Mutex
             }
         });
     }
-    
+
     /**
      * Checks if an exception or any of its previous exceptions is a PDOException.
      *
@@ -145,9 +145,10 @@ class TransactionalMutex extends Mutex
         if ($exception->getPrevious() === null) {
             return false;
         }
+
         return self::hasPDOException($exception->getPrevious());
     }
-    
+
     /**
      * Rolls back a transaction.
      *

--- a/classes/util/DoubleCheckedLocking.php
+++ b/classes/util/DoubleCheckedLocking.php
@@ -32,10 +32,10 @@ class DoubleCheckedLocking
      * Constructs a new instance of the DoubleCheckedLocking pattern.
      *
      * @param \malkusch\lock\mutex\Mutex $mutex Provides methods for exclusive
-     *        code execution.
+     * code execution.
      * @param callable $check Callback that decides if the lock should be
-     *        acquired and if the synchronized callback should be executed after
-     *        acquiring the lock.
+     * acquired and if the critical code callback should be executed after
+     * acquiring the lock.
      */
     public function __construct(Mutex $mutex, callable $check)
     {
@@ -49,21 +49,20 @@ class DoubleCheckedLocking
      *
      * If then returns boolean boolean false, the check did not pass before or
      * after acquiring the lock. A boolean false can also be returned from the
-     * synchronized callback to indicate that processing did not occure or has
+     * critical code callback to indicate that processing did not occure or has
      * failed. It is up to the user to decide the last point.
      *
-     * @param  callable $code The synchronized execution callback.
+     * @param callable $code The critical code callback.
      * @throws \Exception The execution callback or the check threw an
-     *         exception.
+     * exception.
      * @throws \malkusch\lock\exception\LockAcquireException The mutex could not
-     *         be acquired.
+     * be acquired.
      * @throws \malkusch\lock\exception\LockReleaseException The mutex could not
-     *         be released.
+     * be released.
      * @throws \malkusch\lock\exception\ExecutionOutsideLockException Some code
-     *         has been executed outside of the lock.
+     * has been executed outside of the lock.
      * @return mixed Boolean false if check did not pass or mixed for what ever
-     *         the synchronized callback returns.
-     *
+     * the critical code callback returns.
      */
     public function then(callable $code)
     {

--- a/classes/util/DoubleCheckedLocking.php
+++ b/classes/util/DoubleCheckedLocking.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\util;
 
-use malkusch\lock\exception\LockAcquireException;
-use malkusch\lock\exception\LockReleaseException;
 use malkusch\lock\mutex\Mutex;
 
 /**
  * The double-checked locking pattern.
  *
- * You should not instantiate this class directly. Use {@link Mutex::check()}.
+ * You should not instantiate this class directly. Use
+ * {@link \malkusch\lock\mutex\Mutex::check()}.
  *
  * @author Markus Malkusch <markus@malkusch.de>
  * @link bitcoin:1P5FAZ4QhXCuwYPnLZdk3PJsqePbu1UDDA Donations
@@ -17,50 +18,61 @@ use malkusch\lock\mutex\Mutex;
  */
 class DoubleCheckedLocking
 {
-    
     /**
-     * @var Mutex The mutex.
+     * @var \malkusch\lock\mutex\Mutex The mutex.
      */
     private $mutex;
-    
+
     /**
      * @var callable The check.
      */
     private $check;
 
+    /**
+     * Constructs a new instance of the DoubleCheckedLocking pattern.
+     *
+     * @param \malkusch\lock\mutex\Mutex $mutex Provides methods for exclusive
+     *        code execution.
+     * @param callable $check Callback that decides if the lock should be
+     *        acquired and if the synchronized callback should be executed after
+     *        acquiring the lock.
+     */
     public function __construct(Mutex $mutex, callable $check)
     {
         $this->mutex = $mutex;
         $this->check = $check;
     }
-    
+
     /**
-     * Executes a code only if a check is true.
+     * Executes a synchronized callback only after the check callback passes
+     * before and after acquiring the lock.
      *
-     * Both the check and the code execution are locked by a mutex.
-     * Only if the check fails the method returns before acquiring a lock.
+     * If then returns boolean boolean false, the check did not pass before or
+     * after acquiring the lock. A boolean false can also be returned from the
+     * synchronized callback to indicate that processing did not occure or has
+     * failed. It is up to the user to decide the last point.
      *
-     * If then returns boolean FALSE, the check did not pass before or after
-     * acquiring the lock. A boolean FALSE can also be returned from the
-     * synchronized code to indicate that processing did not occure or has
-     * failed. It is up to the user to decide.
+     * @param  callable $code The synchronized execution callback.
+     * @return mixed Boolean false if check did not pass or mixed for what ever
+     *         the synchronized callback returns.
      *
-     * @param  callable $code The locked code.
-     * @return mixed Boolean FALSE if check did not pass or mixed for what ever
-     *               the synchronized code returns.
-     *
-     * @throws \Exception The execution block or the check threw an exception.
-     * @throws LockAcquireException The mutex could not be acquired.
-     * @throws LockReleaseException The mutex could not be released.
+     * @throws \Exception The execution callback or the check threw an
+     *         exception.
+     * @throws \malkusch\lock\exception\LockAcquireException The mutex could not
+     *         be acquired.
+     * @throws \malkusch\lock\exception\LockReleaseException The mutex could not
+     *         be released.
+     * @throws \malkusch\lock\exception\ExecutionOutsideLockException Some code
+     *         has been executed outside of the lock.
      */
     public function then(callable $code)
     {
-        if (!call_user_func($this->check)) {
+        if (!\call_user_func($this->check)) {
             return false;
         }
 
         return $this->mutex->synchronized(function () use ($code) {
-            if (!call_user_func($this->check)) {
+            if (!\call_user_func($this->check)) {
                 return false;
             }
 

--- a/classes/util/DoubleCheckedLocking.php
+++ b/classes/util/DoubleCheckedLocking.php
@@ -53,9 +53,6 @@ class DoubleCheckedLocking
      * failed. It is up to the user to decide the last point.
      *
      * @param  callable $code The synchronized execution callback.
-     * @return mixed Boolean false if check did not pass or mixed for what ever
-     *         the synchronized callback returns.
-     *
      * @throws \Exception The execution callback or the check threw an
      *         exception.
      * @throws \malkusch\lock\exception\LockAcquireException The mutex could not
@@ -64,6 +61,9 @@ class DoubleCheckedLocking
      *         be released.
      * @throws \malkusch\lock\exception\ExecutionOutsideLockException Some code
      *         has been executed outside of the lock.
+     * @return mixed Boolean false if check did not pass or mixed for what ever
+     *         the synchronized callback returns.
+     *
      */
     public function then(callable $code)
     {

--- a/classes/util/Loop.php
+++ b/classes/util/Loop.php
@@ -110,7 +110,7 @@ class Loop
             }
 
             $min = \min(
-                (int) self::MINIMUM_WAIT_US * 1.5 ** $i,
+                (int) (self::MINIMUM_WAIT_US * 1.5 ** $i),
                 self::MAXIMUM_WAIT_US
             );
             $max = \min($min * 2, self::MAXIMUM_WAIT_US);

--- a/classes/util/Loop.php
+++ b/classes/util/Loop.php
@@ -102,7 +102,7 @@ class Loop
             }
 
             // Calculate max time remaining, don't sleep any longer than that.
-            $usecRemaining = \intval(($deadline - \microtime(true))  * 1e6);
+            $usecRemaining = \intval(($deadline - \microtime(true)) * 1e6);
 
             // We've ran out of time.
             if ($usecRemaining <= 0) {

--- a/classes/util/Loop.php
+++ b/classes/util/Loop.php
@@ -102,20 +102,20 @@ class Loop
             }
 
             // Calculate max time remaining, don't sleep any longer than that.
-            $usecRemaining = \intval(($deadline - microtime(true)) * 1e6);
+            $usecRemaining = intval(($deadline - microtime(true)) * 1e6);
 
             // We've ran out of time.
             if ($usecRemaining <= 0) {
                 throw TimeoutException::create($this->timeout);
             }
 
-            $min = \min(
+            $min = min(
                 (int) self::MINIMUM_WAIT_US * 1.5 ** $i,
                 self::MAXIMUM_WAIT_US
             );
-            $max = \min($min * 2, self::MAXIMUM_WAIT_US);
+            $max = min($min * 2, self::MAXIMUM_WAIT_US);
 
-            $usecToSleep = \min($usecRemaining, \random_int((int)$min, (int)$max));
+            $usecToSleep = min($usecRemaining, random_int((int)$min, (int)$max));
 
             usleep($usecToSleep);
         }

--- a/classes/util/Loop.php
+++ b/classes/util/Loop.php
@@ -81,11 +81,11 @@ class Loop
      * If the code throws an exception it will stop repeating the execution.
      *
      * @param callable $code The to be executed code callback.
-     * @return mixed The return value of the executed code callback.
-     *
      * @throws \Exception The execution callback threw an exception.
      * @throws \malkusch\lock\exception\TimeoutException The timeout has been
      *         reached.
+     * @return mixed The return value of the executed code callback.
+     *
      */
     public function execute(callable $code)
     {

--- a/classes/util/Loop.php
+++ b/classes/util/Loop.php
@@ -114,7 +114,8 @@ class Loop
                 self::MAXIMUM_WAIT_US
             );
             $max = \min($min * 2, self::MAXIMUM_WAIT_US);
-            $usecToSleep = \min($usecRemaining, \random_int($min, $max));
+
+            $usecToSleep = \min($usecRemaining, \random_int((int)$min, (int)$max));
 
             \usleep($usecToSleep);
         }

--- a/classes/util/Loop.php
+++ b/classes/util/Loop.php
@@ -92,17 +92,17 @@ class Loop
         $this->looping = true;
 
         // At this time, the lock will time out.
-        $deadline = \microtime(true) + $this->timeout;
+        $deadline = microtime(true) + $this->timeout;
 
         $result = null;
-        for ($i = 0; $this->looping && \microtime(true) < $deadline; ++$i) {
+        for ($i = 0; $this->looping && microtime(true) < $deadline; ++$i) {
             $result = $code();
             if (!$this->looping) {
                 break;
             }
 
             // Calculate max time remaining, don't sleep any longer than that.
-            $usecRemaining = \intval(($deadline - \microtime(true)) * 1e6);
+            $usecRemaining = \intval(($deadline - microtime(true)) * 1e6);
 
             // We've ran out of time.
             if ($usecRemaining <= 0) {
@@ -110,17 +110,17 @@ class Loop
             }
 
             $min = \min(
-                (int) (self::MINIMUM_WAIT_US * 1.5 ** $i),
+                (int) self::MINIMUM_WAIT_US * 1.5 ** $i,
                 self::MAXIMUM_WAIT_US
             );
             $max = \min($min * 2, self::MAXIMUM_WAIT_US);
 
             $usecToSleep = \min($usecRemaining, \random_int((int)$min, (int)$max));
 
-            \usleep($usecToSleep);
+            usleep($usecToSleep);
         }
 
-        if (\microtime(true) >= $deadline) {
+        if (microtime(true) >= $deadline) {
             throw TimeoutException::create($this->timeout);
         }
 

--- a/classes/util/Loop.php
+++ b/classes/util/Loop.php
@@ -44,7 +44,7 @@ class Loop
     /**
      * Sets the timeout. The default is 3 seconds.
      *
-     * @param  int $timeout The timeout in seconds. The default is 3 seconds.
+     * @param int $timeout The timeout in seconds. The default is 3 seconds.
      * @throws \LengthException The timeout must be greater than 0.
      */
     public function __construct(int $timeout = 3)
@@ -83,7 +83,7 @@ class Loop
      * @param callable $code The to be executed code callback.
      * @throws \Exception The execution callback threw an exception.
      * @throws \malkusch\lock\exception\TimeoutException The timeout has been
-     *         reached.
+     * reached.
      * @return mixed The return value of the executed code callback.
      *
      */

--- a/classes/util/Loop.php
+++ b/classes/util/Loop.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\util;
 
+use LengthException;
 use malkusch\lock\exception\TimeoutException;
 
 /**
@@ -14,105 +17,109 @@ use malkusch\lock\exception\TimeoutException;
  */
 class Loop
 {
-
     /**
-     * Minimum time that we want to wait, between lock checks.
+     * Minimum time that we want to wait, between lock checks. In micro seconds.
      *
-     * In micro seconds.
+     * @var double
      */
     private const MINIMUM_WAIT_US = 1e4;
 
     /**
-     * Maximum time that we want to wait, between lock checks.
+     * Maximum time that we want to wait, between lock checks. In micro seconds.
      *
-     * In micro seconds.
+     * @var double
      */
     private const MAXIMUM_WAIT_US = 1e6;
-    
+
     /**
      * @var int The timeout in seconds.
      */
     private $timeout;
-    
+
     /**
-     * @var bool True while code should be repeated.
+     * @var bool True while code execution is repeating.
      */
-    private $looping = false;
-    
+    private $looping;
+
     /**
-     * Sets the timeout.
+     * Sets the timeout. The default is 3 seconds.
      *
-     * The default is 3 seconds.
-     *
-     * @param int $timeout The timeout in seconds.
+     * @param  int $timeout The timeout in seconds. The default is 3 seconds.
      * @throws \LengthException The timeout must be greater than 0.
      */
     public function __construct(int $timeout = 3)
     {
         if ($timeout <= 0) {
-            throw new \LengthException("The timeout must be greater than 0. '$timeout' was given");
+            throw new LengthException(\sprintf(
+                'The timeout must be greater than 0. %d was given.',
+                $timeout
+            ));
         }
+
         $this->timeout = $timeout;
+        $this->looping = false;
     }
-    
+
     /**
      * Notifies that this was the last iteration.
+     *
+     * @return void
      */
     public function end(): void
     {
         $this->looping = false;
     }
-    
+
     /**
      * Repeats executing a code until it was successful.
      *
      * The code has to be designed in a way that it can be repeated without any
      * side effects. When execution was successful it should notify that event
-     * by calling {@link Loop::end()}. I.e. the only side effects
-     * of the code may happen after a successful execution.
+     * by calling {@link \malkusch\lock\util\Loop::end()}. I.e. the only side
+     * effects of the code may happen after a successful execution.
      *
      * If the code throws an exception it will stop repeating the execution.
      *
-     * @param callable $code The executed code block.
-     * @return mixed The return value of the executed block.
+     * @param callable $code The to be executed code callback.
+     * @return mixed The return value of the executed code callback.
      *
-     * @throws \Exception The execution block threw an exception.
-     * @throws TimeoutException The timeout was reached.
+     * @throws \Exception The execution callback threw an exception.
+     * @throws \malkusch\lock\exception\TimeoutException The timeout has been
+     *         reached.
      */
     public function execute(callable $code)
     {
         $this->looping = true;
 
-        $deadline = microtime(true) + $this->timeout; // At this time, the lock will time out.
-        $result = null;
+        // At this time, the lock will time out.
+        $deadline = \microtime(true) + $this->timeout;
 
-        for ($i = 0; $this->looping && microtime(true) < $deadline; $i++) {
+        $result = null;
+        for ($i = 0; $this->looping && \microtime(true) < $deadline; ++$i) {
             $result = $code();
             if (!$this->looping) {
                 break;
             }
 
-            /*
-             * Calculate max time remaining, don't sleep any longer than that.
-             */
-            $usecRemaining = \intval(($deadline - microtime(true))  * 1e6);
+            // Calculate max time remaining, don't sleep any longer than that.
+            $usecRemaining = \intval(($deadline - \microtime(true))  * 1e6);
 
+            // We've ran out of time.
             if ($usecRemaining <= 0) {
-                /*
-                 * We've ran out of time.
-                 */
                 throw TimeoutException::create($this->timeout);
             }
 
-            $min = min((int) self::MINIMUM_WAIT_US * 1.5 ** $i, self::MAXIMUM_WAIT_US);
-            $max = min($min * 2, self::MAXIMUM_WAIT_US);
-
+            $min = \min(
+                (int) self::MINIMUM_WAIT_US * 1.5 ** $i,
+                self::MAXIMUM_WAIT_US
+            );
+            $max = \min($min * 2, self::MAXIMUM_WAIT_US);
             $usecToSleep = \min($usecRemaining, \random_int($min, $max));
 
-            usleep($usecToSleep);
+            \usleep($usecToSleep);
         }
 
-        if (microtime(true) >= $deadline) {
+        if (\microtime(true) >= $deadline) {
             throw TimeoutException::create($this->timeout);
         }
 

--- a/classes/util/PcntlTimeout.php
+++ b/classes/util/PcntlTimeout.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace malkusch\lock\util;
 
+use InvalidArgumentException;
 use malkusch\lock\exception\DeadlineException;
 use malkusch\lock\exception\LockAcquireException;
+use RuntimeException;
 
 /**
  * Timeout based on a scheduled alarm.
@@ -25,32 +29,40 @@ final class PcntlTimeout
     /**
      * Builds the timeout.
      *
-     * @param int $timeout Timeout in seconds
+     * @param  int $timeout Timeout in seconds.
+     * @throws \RuntimeException When the PCNTL module is not enabled.
+     * @throws \InvalidArgumentException When the timeout is zero or negative.
      */
     public function __construct(int $timeout)
     {
         if (!self::isSupported()) {
-            throw new \RuntimeException('PCNTL module not enabled');
+            throw new RuntimeException('PCNTL module not enabled');
         }
+
         if ($timeout <= 0) {
-            throw new \InvalidArgumentException('Timeout must be positive and non zero');
+            throw new InvalidArgumentException(
+                'Timeout must be positive and non zero'
+            );
         }
+
         $this->timeout = $timeout;
     }
 
     /**
      * Runs the code and would eventually time out.
      *
-     * This method has the side effect, that any signal handler
-     * for SIGALRM will be reset to the default hanlder (SIG_DFL).
-     * It also expects that there is no previously scheduled alarm.
-     * If your application uses alarms ({@link pcntl_alarm()}) or
-     * a signal handler for SIGALRM, don't use this method. It will
-     * interfer with your application and lead to unexpected behaviour.
+     * This method has the side effect, that any signal handler for SIGALRM will
+     * be reset to the default hanlder (SIG_DFL). It also expects that there is
+     * no previously scheduled alarm. If your application uses alarms
+     * ({@link pcntl_alarm()}) or a signal handler for SIGALRM, don't use this
+     * method. It will interfer with your application and lead to unexpected
+     * behaviour.
      *
-     * @param callable $code Executed code block
-     * @throws DeadlineException Running the code hit the deadline
-     * @throws LockAcquireException Installing the timeout failed
+     * @param  callable $code Executed code block
+     * @throws \malkusch\lock\exception\DeadlineException
+     *             Running the code hit the deadline.
+     * @throws \malkusch\lock\exception\LockAcquireException
+     *             Installing the timeout failed.
      * @return mixed Return value of the executed block
      *
      */
@@ -59,15 +71,20 @@ final class PcntlTimeout
         $existingHandler = pcntl_signal_get_handler(SIGALRM);
 
         $signal = pcntl_signal(SIGALRM, function (): void {
-            throw new DeadlineException(sprintf('Timebox hit deadline of %d seconds', $this->timeout));
+            throw new DeadlineException(sprintf(
+                'Timebox hit deadline of %d seconds',
+                $this->timeout
+            ));
         });
         if (!$signal) {
             throw new LockAcquireException('Could not install signal');
         }
+
         $oldAlarm = pcntl_alarm($this->timeout);
         if ($oldAlarm != 0) {
             throw new LockAcquireException('Existing alarm was not expected');
         }
+
         try {
             return $code();
         } finally {

--- a/classes/util/PcntlTimeout.php
+++ b/classes/util/PcntlTimeout.php
@@ -29,7 +29,7 @@ final class PcntlTimeout
     /**
      * Builds the timeout.
      *
-     * @param  int $timeout Timeout in seconds.
+     * @param int $timeout Timeout in seconds.
      * @throws \RuntimeException When the PCNTL module is not enabled.
      * @throws \InvalidArgumentException When the timeout is zero or negative.
      */
@@ -59,12 +59,11 @@ final class PcntlTimeout
      * behaviour.
      *
      * @param  callable $code Executed code block
-     * @throws \malkusch\lock\exception\DeadlineException
-     *             Running the code hit the deadline.
-     * @throws \malkusch\lock\exception\LockAcquireException
-     *             Installing the timeout failed.
+     * @throws \malkusch\lock\exception\DeadlineException Running the code hit
+     * the deadline.
+     * @throws \malkusch\lock\exception\LockAcquireException Installing the
+     * timeout failed.
      * @return mixed Return value of the executed block
-     *
      */
     public function timeBoxed(callable $code)
     {

--- a/classes/util/PcntlTimeout.php
+++ b/classes/util/PcntlTimeout.php
@@ -3,7 +3,6 @@
 namespace malkusch\lock\util;
 
 use malkusch\lock\exception\DeadlineException;
-use malkusch\lock\exception\TimeoutException;
 use malkusch\lock\exception\LockAcquireException;
 
 /**
@@ -18,7 +17,6 @@ use malkusch\lock\exception\LockAcquireException;
  */
 final class PcntlTimeout
 {
-
     /**
      * @var int Timeout in seconds
      */
@@ -32,10 +30,10 @@ final class PcntlTimeout
     public function __construct(int $timeout)
     {
         if (!self::isSupported()) {
-            throw new \RuntimeException("PCNTL module not enabled");
+            throw new \RuntimeException('PCNTL module not enabled');
         }
         if ($timeout <= 0) {
-            throw new \InvalidArgumentException("Timeout must be positive and non zero");
+            throw new \InvalidArgumentException('Timeout must be positive and non zero');
         }
         $this->timeout = $timeout;
     }
@@ -51,24 +49,24 @@ final class PcntlTimeout
      * interfer with your application and lead to unexpected behaviour.
      *
      * @param callable $code Executed code block
-     * @return mixed Return value of the executed block
-     *
      * @throws DeadlineException Running the code hit the deadline
      * @throws LockAcquireException Installing the timeout failed
+     * @return mixed Return value of the executed block
+     *
      */
     public function timeBoxed(callable $code)
     {
         $existingHandler = pcntl_signal_get_handler(SIGALRM);
 
         $signal = pcntl_signal(SIGALRM, function (): void {
-            throw new DeadlineException(sprintf("Timebox hit deadline of %d seconds", $this->timeout));
+            throw new DeadlineException(sprintf('Timebox hit deadline of %d seconds', $this->timeout));
         });
         if (!$signal) {
-            throw new LockAcquireException("Could not install signal");
+            throw new LockAcquireException('Could not install signal');
         }
         $oldAlarm = pcntl_alarm($this->timeout);
         if ($oldAlarm != 0) {
-            throw new LockAcquireException("Existing alarm was not expected");
+            throw new LockAcquireException('Existing alarm was not expected');
         }
         try {
             return $code();
@@ -90,10 +88,10 @@ final class PcntlTimeout
     public static function isSupported(): bool
     {
         return
-            PHP_SAPI === "cli" &&
-            extension_loaded("pcntl") &&
-            function_exists("pcntl_alarm") &&
-            function_exists("pcntl_signal") &&
-            function_exists("pcntl_signal_dispatch");
+            PHP_SAPI === 'cli' &&
+            extension_loaded('pcntl') &&
+            function_exists('pcntl_alarm') &&
+            function_exists('pcntl_signal') &&
+            function_exists('pcntl_signal_dispatch');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "ext-redis": "*",
         "ext-sysvsem": "*",
         "eloquent/liberator": "^2.0",
+        "friendsofphp/php-cs-fixer": "^2.14",
         "johnkary/phpunit-speedtrap": "^3.0",
         "kriswallsmith/spork": "^0.3",
         "mikey179/vfsStream": "^1.6",

--- a/tests/mutex/CASMutexTest.php
+++ b/tests/mutex/CASMutexTest.php
@@ -17,17 +17,17 @@ use PHPUnit\Framework\TestCase;
 class CASMutexTest extends TestCase
 {
     use PHPMock;
-    
+
     protected function setUp()
     {
         parent::setUp();
-        
+
         $builder = new SleepEnvironmentBuilder();
         $builder->addNamespace(__NAMESPACE__);
         $builder->addNamespace('malkusch\lock\util');
         $sleep = $builder->build();
         $sleep->enable();
-        
+
         $this->registerForTearDown($sleep);
     }
 
@@ -63,7 +63,7 @@ class CASMutexTest extends TestCase
      */
     public function testNotify()
     {
-        $i     = 0;
+        $i = 0;
         $mutex = new CASMutex();
         $mutex->synchronized(function () use ($mutex, &$i) {
             $i++;
@@ -78,7 +78,7 @@ class CASMutexTest extends TestCase
      */
     public function testIteration()
     {
-        $i     = 0;
+        $i = 0;
         $mutex = new CASMutex();
         $mutex->synchronized(function () use ($mutex, &$i): void {
             $i++;

--- a/tests/mutex/FlockMutexTest.php
+++ b/tests/mutex/FlockMutexTest.php
@@ -28,8 +28,8 @@ class FlockMutexTest extends TestCase
     {
         parent::setUp();
 
-        $this->file = tempnam(sys_get_temp_dir(), "flock-");
-        $this->mutex = Liberator::liberate(new FlockMutex(fopen($this->file, "r"), 1));
+        $this->file = tempnam(sys_get_temp_dir(), 'flock-');
+        $this->mutex = Liberator::liberate(new FlockMutex(fopen($this->file, 'r'), 1));
     }
 
     protected function tearDown()
@@ -48,6 +48,7 @@ class FlockMutexTest extends TestCase
 
         $this->assertTrue($this->mutex->synchronized(function (): bool {
             usleep(1.1e6);
+
             return true;
         }));
     }
@@ -59,7 +60,7 @@ class FlockMutexTest extends TestCase
      */
     public function testTimeoutOccurs(int $strategy)
     {
-        $another_resource = fopen($this->file, "r");
+        $another_resource = fopen($this->file, 'r');
         flock($another_resource, LOCK_EX);
 
         $this->mutex->strategy = $strategy;
@@ -67,7 +68,7 @@ class FlockMutexTest extends TestCase
         try {
             $this->mutex->synchronized(
                 function () {
-                    $this->fail("Did not expect code to be executed");
+                    $this->fail('Did not expect code to be executed');
                 }
             );
         } finally {
@@ -88,7 +89,7 @@ class FlockMutexTest extends TestCase
      */
     public function testNoTimeoutWaitsForever()
     {
-        $another_resource = fopen($this->file, "r");
+        $another_resource = fopen($this->file, 'r');
         flock($another_resource, LOCK_EX);
 
         $this->mutex->strategy = FlockMutex::STRATEGY_BLOCK;
@@ -96,7 +97,7 @@ class FlockMutexTest extends TestCase
         $timebox = new PcntlTimeout(1);
         $timebox->timeBoxed(function () {
             $this->mutex->synchronized(function () {
-                $this->fail("Did not expect code execution.");
+                $this->fail('Did not expect code execution.');
             });
         });
     }

--- a/tests/mutex/LockMutexTest.php
+++ b/tests/mutex/LockMutexTest.php
@@ -4,7 +4,6 @@ namespace malkusch\lock\mutex;
 
 use malkusch\lock\exception\LockAcquireException;
 use malkusch\lock\exception\LockReleaseException;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,11 +20,11 @@ class LockMutexTest extends TestCase
      * @var \PHPUnit\Framework\MockObject\MockObject The SUT
      */
     private $mutex;
-    
+
     protected function setUp()
     {
         parent::setUp();
-        
+
         $this->mutex = $this->getMockForAbstractClass(LockMutex::class);
     }
 
@@ -37,14 +36,14 @@ class LockMutexTest extends TestCase
     public function testLockFails()
     {
         $this->mutex->expects($this->once())
-            ->method("lock")
+            ->method('lock')
             ->willThrowException(new LockAcquireException());
-        
+
         $this->mutex->synchronized(function () {
-            $this->fail("Should not execute code.");
+            $this->fail('Should not execute code.');
         });
     }
-    
+
     /**
      * Tests unlock() is called after the code was executed.
      *
@@ -52,12 +51,12 @@ class LockMutexTest extends TestCase
     public function testUnlockAfterCode()
     {
         $this->mutex->expects($this->once())
-            ->method("unlock");
-        
+            ->method('unlock');
+
         $this->mutex->synchronized(function (): void {
         });
     }
-    
+
     /**
      * Tests unlock() is called after an exception.
      *
@@ -65,15 +64,14 @@ class LockMutexTest extends TestCase
     public function testUnlockAfterException()
     {
         $this->mutex->expects($this->once())
-            ->method("unlock");
-        
+            ->method('unlock');
 
         $this->expectException(\DomainException::class);
         $this->mutex->synchronized(function () {
             throw new \DomainException();
         });
     }
-    
+
     /**
      * Tests unlock() fails after the code was executed.
      *
@@ -82,13 +80,13 @@ class LockMutexTest extends TestCase
     public function testUnlockFailsAfterCode()
     {
         $this->mutex->expects($this->once())
-            ->method("unlock")
+            ->method('unlock')
             ->willThrowException(new LockReleaseException());
-        
+
         $this->mutex->synchronized(function () {
         });
     }
-    
+
     /**
      * Tests unlock() fails after the code threw an exception.
      *
@@ -97,9 +95,9 @@ class LockMutexTest extends TestCase
     public function testUnlockFailsAfterException()
     {
         $this->mutex->expects($this->once())
-            ->method("unlock")
+            ->method('unlock')
             ->willThrowException(new LockReleaseException());
-        
+
         $this->mutex->synchronized(function () {
             throw new \DomainException();
         });
@@ -111,15 +109,15 @@ class LockMutexTest extends TestCase
     public function testCodeResultAvailableAfterFailedUnlock()
     {
         $this->mutex->expects($this->once())
-            ->method("unlock")
+            ->method('unlock')
             ->willThrowException(new LockReleaseException());
 
         try {
             $this->mutex->synchronized(function () {
-                return "result";
+                return 'result';
             });
         } catch (LockReleaseException $exception) {
-            $this->assertEquals("result", $exception->getCodeResult());
+            $this->assertEquals('result', $exception->getCodeResult());
             $this->assertNull($exception->getCodeException());
         }
     }
@@ -130,16 +128,16 @@ class LockMutexTest extends TestCase
     public function testCodeExceptionAvailableAfterFailedUnlock()
     {
         $this->mutex->expects($this->once())
-            ->method("unlock")
+            ->method('unlock')
             ->willThrowException(new LockReleaseException());
 
         try {
             $this->mutex->synchronized(function () {
-                throw new \DomainException("Domain exception");
+                throw new \DomainException('Domain exception');
             });
         } catch (LockReleaseException $exception) {
             $this->assertInstanceOf(\DomainException::class, $exception->getCodeException());
-            $this->assertEquals("Domain exception", $exception->getCodeException()->getMessage());
+            $this->assertEquals('Domain exception', $exception->getCodeException()->getMessage());
         }
     }
 }

--- a/tests/mutex/MemcachedMutexTest.php
+++ b/tests/mutex/MemcachedMutexTest.php
@@ -2,8 +2,6 @@
 
 namespace malkusch\lock\mutex;
 
-use phpmock\environment\SleepEnvironmentBuilder;
-use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -33,7 +31,7 @@ class MemcachedMutexTest extends TestCase
     protected function setUp()
     {
         $this->memcached = $this->createMock(\Memcached::class);
-        $this->mutex = new MemcachedMutex("test", $this->memcached, 1);
+        $this->mutex = new MemcachedMutex('test', $this->memcached, 1);
     }
 
     /**
@@ -44,15 +42,15 @@ class MemcachedMutexTest extends TestCase
     public function testFailAcquireLock()
     {
         $this->memcached->expects($this->atLeastOnce())
-            ->method("add")
-            ->with("lock_test", true, 2)
+            ->method('add')
+            ->with('lock_test', true, 2)
             ->willReturn(false);
 
         $this->mutex->synchronized(function (): void {
-            $this->fail("execution is not expected");
+            $this->fail('execution is not expected');
         });
     }
-    
+
     /**
      * Tests failing to release a lock.
      *
@@ -61,13 +59,13 @@ class MemcachedMutexTest extends TestCase
     public function testFailReleasingLock()
     {
         $this->memcached->expects($this->once())
-            ->method("add")
-            ->with("lock_test", true, 2)
+            ->method('add')
+            ->with('lock_test', true, 2)
             ->willReturn(true);
 
         $this->memcached->expects($this->once())
-            ->method("delete")
-            ->with("lock_test")
+            ->method('delete')
+            ->with('lock_test')
             ->willReturn(false);
 
         $this->mutex->synchronized(function (): void {

--- a/tests/mutex/MutexTest.php
+++ b/tests/mutex/MutexTest.php
@@ -28,7 +28,7 @@ class MutexTest extends TestCase
 
     public static function setUpBeforeClass()
     {
-        vfsStream::setup("test");
+        vfsStream::setup('test');
     }
 
     /**
@@ -39,130 +39,136 @@ class MutexTest extends TestCase
     public function provideMutexFactories()
     {
         $cases = [
-            "NoMutex" => [function (): Mutex {
+            'NoMutex' => [function (): Mutex {
                 return new NoMutex();
             }],
 
-            "TransactionalMutex" => [function (): Mutex {
-                $pdo = new \PDO("sqlite::memory:");
+            'TransactionalMutex' => [function (): Mutex {
+                $pdo = new \PDO('sqlite::memory:');
                 $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
                 return new TransactionalMutex($pdo, self::TIMEOUT);
             }],
 
-            "FlockMutex" => [function (): Mutex {
-                $file = fopen(vfsStream::url("test/lock"), "w");
+            'FlockMutex' => [function (): Mutex {
+                $file = fopen(vfsStream::url('test/lock'), 'w');
+
                 return new FlockMutex($file);
             }],
 
-            "flockWithTimoutPcntl" => [function (): Mutex {
-                $file = fopen(vfsStream::url("test/lock"), "w");
+            'flockWithTimoutPcntl' => [function (): Mutex {
+                $file = fopen(vfsStream::url('test/lock'), 'w');
                 $lock = Liberator::liberate(new FlockMutex($file, 3));
                 $lock->stategy = FlockMutex::STRATEGY_PCNTL;
 
                 return $lock->popsValue();
             }],
 
-            "flockWithTimoutBusy" => [function ($timeout = 3): Mutex {
-                $file = fopen(vfsStream::url("test/lock"), "w");
+            'flockWithTimoutBusy' => [function ($timeout = 3): Mutex {
+                $file = fopen(vfsStream::url('test/lock'), 'w');
                 $lock = Liberator::liberate(new FlockMutex($file, 3));
                 $lock->stategy = FlockMutex::STRATEGY_BUSY;
 
                 return $lock->popsValue();
             }],
 
-            "SemaphoreMutex" => [function (): Mutex {
-                return new SemaphoreMutex(sem_get(ftok(__FILE__, "a")));
+            'SemaphoreMutex' => [function (): Mutex {
+                return new SemaphoreMutex(sem_get(ftok(__FILE__, 'a')));
             }],
 
-            "SpinlockMutex" => [function (): Mutex {
-                $mock = $this->getMockForAbstractClass(SpinlockMutex::class, ["test"]);
+            'SpinlockMutex' => [function (): Mutex {
+                $mock = $this->getMockForAbstractClass(SpinlockMutex::class, ['test']);
                 $mock->expects($this->atLeastOnce())
-                    ->method("acquire")
+                    ->method('acquire')
                     ->willReturn(true);
 
                 $mock->expects($this->atLeastOnce())
-                    ->method("release")
+                    ->method('release')
                     ->willReturn(true);
+
                 return $mock;
             }],
 
-            "LockMutex" => [function (): Mutex {
+            'LockMutex' => [function (): Mutex {
                 $mock = $this->getMockForAbstractClass(LockMutex::class);
                 $mock->expects($this->atLeastOnce())
-                    ->method("lock")
+                    ->method('lock')
                     ->willReturn(true);
 
                 $mock->expects($this->atLeastOnce())
-                    ->method("unlock")
+                    ->method('unlock')
                     ->willReturn(true);
 
                 return $mock;
             }],
         ];
 
-        if (getenv("MEMCACHE_HOST")) {
-            $cases["MemcachedMutex"] = [function (): Mutex {
+        if (getenv('MEMCACHE_HOST')) {
+            $cases['MemcachedMutex'] = [function (): Mutex {
                 $memcache = new Memcached();
-                $memcache->addServer(getenv("MEMCACHE_HOST"), 11211);
-                return new MemcachedMutex("test", $memcache, self::TIMEOUT);
+                $memcache->addServer(getenv('MEMCACHE_HOST'), 11211);
+
+                return new MemcachedMutex('test', $memcache, self::TIMEOUT);
             }];
         }
 
-        if (getenv("REDIS_URIS")) {
-            $uris = explode(",", getenv("REDIS_URIS"));
+        if (getenv('REDIS_URIS')) {
+            $uris = explode(',', getenv('REDIS_URIS'));
 
-            $cases["PredisMutex"] = [function () use ($uris): Mutex {
+            $cases['PredisMutex'] = [function () use ($uris): Mutex {
                 $clients = array_map(
                     function ($uri) {
                         return new Client($uri);
                     },
                     $uris
                 );
-                return new PredisMutex($clients, "test", self::TIMEOUT);
+
+                return new PredisMutex($clients, 'test', self::TIMEOUT);
             }];
 
-            $cases["PHPRedisMutex"] = [function () use ($uris): Mutex {
+            $cases['PHPRedisMutex'] = [function () use ($uris): Mutex {
                 /** @var Redis[] $apis */
                 $apis = array_map(
                     function ($uri) {
                         $redis = new Redis();
-                        
+
                         $uri = parse_url($uri);
-                        if (!empty($uri["port"])) {
-                            $redis->connect($uri["host"], $uri["port"]);
+                        if (!empty($uri['port'])) {
+                            $redis->connect($uri['host'], $uri['port']);
                         } else {
-                            $redis->connect($uri["host"]);
+                            $redis->connect($uri['host']);
                         }
-                        
+
                         return $redis;
                     },
                     $uris
                 );
-                return new PHPRedisMutex($apis, "test", self::TIMEOUT);
+
+                return new PHPRedisMutex($apis, 'test', self::TIMEOUT);
             }];
         }
 
-        if (getenv("MYSQL_DSN")) {
-            $cases["MySQLMutex"] = [function (): Mutex {
-                $pdo = new \PDO(getenv("MYSQL_DSN"), getenv("MYSQL_USER"));
+        if (getenv('MYSQL_DSN')) {
+            $cases['MySQLMutex'] = [function (): Mutex {
+                $pdo = new \PDO(getenv('MYSQL_DSN'), getenv('MYSQL_USER'));
                 $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
-                return new MySQLMutex($pdo, "test" . time(), self::TIMEOUT);
+                return new MySQLMutex($pdo, 'test' . time(), self::TIMEOUT);
             }];
         }
 
-        if (getenv("PGSQL_DSN")) {
-            $cases["PgAdvisoryLockMutex"] = [function (): Mutex {
-                $pdo = new \PDO(getenv("PGSQL_DSN"), getenv("PGSQL_USER"));
+        if (getenv('PGSQL_DSN')) {
+            $cases['PgAdvisoryLockMutex'] = [function (): Mutex {
+                $pdo = new \PDO(getenv('PGSQL_DSN'), getenv('PGSQL_USER'));
                 $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
-                return new PgAdvisoryLockMutex($pdo, "test");
+                return new PgAdvisoryLockMutex($pdo, 'test');
             }];
         }
 
         return $cases;
     }
-    
+
     /**
      * Tests synchronized() executes the code and returns its result.
      *
@@ -172,13 +178,13 @@ class MutexTest extends TestCase
     public function testSynchronizedDelegates(callable $mutexFactory)
     {
         /** @var Mutex $mutex */
-        $mutex  = $mutexFactory();
+        $mutex = $mutexFactory();
         $result = $mutex->synchronized(function () {
-            return "test";
+            return 'test';
         });
-        $this->assertSame("test", $result);
+        $this->assertSame('test', $result);
     }
-    
+
     /**
      * Tests that synchronized() released the lock.
      *

--- a/tests/mutex/PHPRedisMutexTest.php
+++ b/tests/mutex/PHPRedisMutexTest.php
@@ -35,14 +35,13 @@ class PHPRedisMutexTest extends TestCase
     {
         parent::setUp();
 
-        $uris = explode(",", getenv("REDIS_URIS") ?: "redis://localhost");
+        $uris = explode(',', getenv('REDIS_URIS') ?: 'redis://localhost');
 
         foreach ($uris as $redisUri) {
-            $uri  = parse_url($redisUri);
+            $uri = parse_url($redisUri);
 
             // original Redis::set and Redis::eval calls will reopen the connection
-            $connection = new class extends Redis
-            {
+            $connection = new class extends Redis {
                 private $is_closed = false;
 
                 public function close()
@@ -60,7 +59,7 @@ class PHPRedisMutexTest extends TestCase
                     return parent::set($key, $value, $timeout);
                 }
 
-                public function eval($script, $args = array(), $numKeys = 0)
+                public function eval($script, $args = [], $numKeys = 0)
                 {
                     if ($this->is_closed) {
                         throw new \RedisException('Connection is closed');
@@ -70,10 +69,10 @@ class PHPRedisMutexTest extends TestCase
                 }
             };
 
-            if (!empty($uri["port"])) {
-                $connection->connect($uri["host"], $uri["port"]);
+            if (!empty($uri['port'])) {
+                $connection->connect($uri['host'], $uri['port']);
             } else {
-                $connection->connect($uri["host"]);
+                $connection->connect($uri['host']);
             }
 
             $connection->flushAll(); // Clear any existing locks.
@@ -81,7 +80,7 @@ class PHPRedisMutexTest extends TestCase
             $this->connections[] = $connection;
         }
 
-        $this->mutex = new PHPRedisMutex($this->connections, "test");
+        $this->mutex = new PHPRedisMutex($this->connections, 'test');
     }
 
     private function closeMajorityConnections()
@@ -96,7 +95,7 @@ class PHPRedisMutexTest extends TestCase
     private function closeMinorityConnections()
     {
         if (count($this->connections) === 1) {
-            $this->markTestSkipped("Cannot test this with only a single Redis server");
+            $this->markTestSkipped('Cannot test this with only a single Redis server');
         }
 
         $numberToClose = ceil(count($this->connections) / 2) - 1;
@@ -115,7 +114,7 @@ class PHPRedisMutexTest extends TestCase
         $this->closeMajorityConnections();
 
         $this->mutex->synchronized(function (): void {
-            $this->fail("Code execution is not expected");
+            $this->fail('Code execution is not expected');
         });
     }
 
@@ -141,8 +140,8 @@ class PHPRedisMutexTest extends TestCase
             $connection->setOption(Redis::OPT_SERIALIZER, $serialization);
         }
 
-        $this->assertSame("test", $this->mutex->synchronized(function (): string {
-            return "test";
+        $this->assertSame('test', $this->mutex->synchronized(function (): string {
+            return 'test';
         }));
     }
 
@@ -150,8 +149,8 @@ class PHPRedisMutexTest extends TestCase
     {
         $this->closeMinorityConnections();
 
-        $this->assertSame("test", $this->mutex->synchronized(function (): string {
-            return "test";
+        $this->assertSame('test', $this->mutex->synchronized(function (): string {
+            return 'test';
         }));
     }
 
@@ -159,6 +158,7 @@ class PHPRedisMutexTest extends TestCase
     {
         $this->assertNull($this->mutex->synchronized(function () {
             $this->closeMinorityConnections();
+
             return null;
         }));
     }
@@ -174,8 +174,8 @@ class PHPRedisMutexTest extends TestCase
             [Redis::SERIALIZER_PHP],
         ];
 
-        if (defined("Redis::SERIALIZER_IGBINARY")) {
-            $serializers[] = [constant("Redis::SERIALIZER_IGBINARY")];
+        if (defined('Redis::SERIALIZER_IGBINARY')) {
+            $serializers[] = [constant('Redis::SERIALIZER_IGBINARY')];
         }
 
         return $serializers;

--- a/tests/mutex/PgAdvisoryLockMutexTest.php
+++ b/tests/mutex/PgAdvisoryLockMutexTest.php
@@ -20,14 +20,14 @@ class PgAdvisoryLockMutexTest extends TestCase
      * @var PgAdvisoryLockMutex
      */
     private $mutex;
-    
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->pdo = $this->createMock(\PDO::class);
 
-        $this->mutex = new PgAdvisoryLockMutex($this->pdo, "test" . uniqid());
+        $this->mutex = new PgAdvisoryLockMutex($this->pdo, 'test' . uniqid());
     }
 
     public function testAcquireLock()
@@ -35,21 +35,21 @@ class PgAdvisoryLockMutexTest extends TestCase
         $statement = $this->createMock(\PDOStatement::class);
 
         $this->pdo->expects($this->once())
-            ->method("prepare")
-            ->with("SELECT pg_advisory_lock(?,?)")
+            ->method('prepare')
+            ->with('SELECT pg_advisory_lock(?,?)')
             ->willReturn($statement);
 
         $statement->expects($this->once())
-            ->method("execute")
+            ->method('execute')
             ->with(
                 $this->logicalAnd(
-                    $this->isType("array"),
+                    $this->isType('array'),
                     $this->countOf(2),
                     $this->callback(function (...$arguments) {
                         $integers = $arguments[0];
 
                         foreach ($integers as $each) {
-                            $this->assertInternalType("integer", $each);
+                            $this->assertInternalType('integer', $each);
                         }
 
                         return true;
@@ -65,15 +65,15 @@ class PgAdvisoryLockMutexTest extends TestCase
         $statement = $this->createMock(\PDOStatement::class);
 
         $this->pdo->expects($this->once())
-            ->method("prepare")
-            ->with("SELECT pg_advisory_unlock(?,?)")
+            ->method('prepare')
+            ->with('SELECT pg_advisory_unlock(?,?)')
             ->willReturn($statement);
 
         $statement->expects($this->once())
-            ->method("execute")
+            ->method('execute')
             ->with(
                 $this->logicalAnd(
-                    $this->isType("array"),
+                    $this->isType('array'),
                     $this->countOf(2),
                     $this->callback(function (...$arguments): bool {
                         $integers = $arguments[0];
@@ -81,7 +81,7 @@ class PgAdvisoryLockMutexTest extends TestCase
                         foreach ($integers as $each) {
                             $this->assertLessThan(1 << 32, $each);
                             $this->assertGreaterThan(-(1 << 32), $each);
-                            $this->assertInternalType("integer", $each);
+                            $this->assertInternalType('integer', $each);
                         }
 
                         return true;

--- a/tests/mutex/PredisMutexTest.php
+++ b/tests/mutex/PredisMutexTest.php
@@ -38,10 +38,10 @@ class PredisMutexTest extends TestCase
         parent::setUp();
 
         $this->client = $this->getMockBuilder(ClientInterface::class)
-            ->setMethods(array_merge(get_class_methods(ClientInterface::class), ["set", "eval"]))
+            ->setMethods(array_merge(get_class_methods(ClientInterface::class), ['set', 'eval']))
             ->getMock();
 
-        $this->mutex = new PredisMutex([$this->client], "test");
+        $this->mutex = new PredisMutex([$this->client], 'test');
 
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->mutex->setLogger($this->logger);
@@ -55,16 +55,16 @@ class PredisMutexTest extends TestCase
     public function testAddFailsToSetKey()
     {
         $this->client->expects($this->atLeastOnce())
-            ->method("set")
-            ->with("lock_test", $this->isType("string"), "EX", 4, "NX")
+            ->method('set')
+            ->with('lock_test', $this->isType('string'), 'EX', 4, 'NX')
             ->willReturn(null);
 
         $this->logger->expects($this->never())
-            ->method("warning");
+            ->method('warning');
 
         $this->mutex->synchronized(
             function () {
-                $this->fail("Code execution is not expected");
+                $this->fail('Code execution is not expected');
             }
         );
     }
@@ -77,17 +77,17 @@ class PredisMutexTest extends TestCase
     public function testAddErrors()
     {
         $this->client->expects($this->atLeastOnce())
-            ->method("set")
-            ->with("lock_test", $this->isType("string"), "EX", 4, "NX")
+            ->method('set')
+            ->with('lock_test', $this->isType('string'), 'EX', 4, 'NX')
             ->willThrowException($this->createMock(PredisException::class));
 
         $this->logger->expects($this->once())
-            ->method("warning")
-            ->with("Could not set {key} = {token} at server #{index}.", $this->anything());
+            ->method('warning')
+            ->with('Could not set {key} = {token} at server #{index}.', $this->anything());
 
         $this->mutex->synchronized(
             function () {
-                $this->fail("Code execution is not expected");
+                $this->fail('Code execution is not expected');
             }
         );
     }
@@ -95,13 +95,13 @@ class PredisMutexTest extends TestCase
     public function testWorksNormally()
     {
         $this->client->expects($this->atLeastOnce())
-            ->method("set")
-            ->with("lock_test", $this->isType("string"), "EX", 4, "NX")
+            ->method('set')
+            ->with('lock_test', $this->isType('string'), 'EX', 4, 'NX')
             ->willReturnSelf();
 
         $this->client->expects($this->once())
-            ->method("eval")
-            ->with($this->anything(), 1, "lock_test", $this->isType("string"))
+            ->method('eval')
+            ->with($this->anything(), 1, 'lock_test', $this->isType('string'))
             ->willReturn(true);
 
         $executed = false;
@@ -121,18 +121,18 @@ class PredisMutexTest extends TestCase
     public function testEvalScriptFails()
     {
         $this->client->expects($this->atLeastOnce())
-            ->method("set")
-            ->with("lock_test", $this->isType("string"), "EX", 4, "NX")
+            ->method('set')
+            ->with('lock_test', $this->isType('string'), 'EX', 4, 'NX')
             ->willReturnSelf();
 
         $this->client->expects($this->once())
-            ->method("eval")
-            ->with($this->anything(), 1, "lock_test", $this->isType("string"))
+            ->method('eval')
+            ->with($this->anything(), 1, 'lock_test', $this->isType('string'))
             ->willThrowException($this->createMock(PredisException::class));
 
         $this->logger->expects($this->once())
-            ->method("warning")
-            ->with("Could not unset {key} = {token} at server #{index}.", $this->anything());
+            ->method('warning')
+            ->with('Could not unset {key} = {token} at server #{index}.', $this->anything());
 
         $executed = false;
 

--- a/tests/mutex/RedisMutexTest.php
+++ b/tests/mutex/RedisMutexTest.php
@@ -21,11 +21,11 @@ use PHPUnit\Framework\TestCase;
 class RedisMutexTest extends TestCase
 {
     use PHPMock;
-    
+
     protected function setUp()
     {
         parent::setUp();
-        
+
         $sleepBuilder = new SleepEnvironmentBuilder();
         $sleepBuilder->addNamespace(__NAMESPACE__);
         $sleepBuilder->addNamespace('malkusch\lock\util');
@@ -47,14 +47,14 @@ class RedisMutexTest extends TestCase
     {
         $redisAPIs = array_map(
             function ($id): array {
-                return ["id" => $id];
+                return ['id' => $id];
             },
             range(1, $count)
         );
 
-        return $this->getMockForAbstractClass(RedisMutex::class, [$redisAPIs, "test", $timeout]);
+        return $this->getMockForAbstractClass(RedisMutex::class, [$redisAPIs, 'test', $timeout]);
     }
-    
+
     /**
      * Tests acquire() fails because too few servers are available.
      *
@@ -68,26 +68,27 @@ class RedisMutexTest extends TestCase
     public function testTooFewServerToAcquire(int $count, int $available)
     {
         $mutex = $this->buildRedisMutex($count);
-        
+
         $i = 0;
         $mutex->expects($this->exactly($count))
-            ->method("add")
+            ->method('add')
             ->willReturnCallback(
                 function () use (&$i, $available): bool {
                     if ($i < $available) {
                         $i++;
+
                         return true;
                     } else {
                         throw new LockAcquireException();
                     }
                 }
             );
-        
+
         $mutex->synchronized(function (): void {
-            $this->fail("Code should not be executed");
+            $this->fail('Code should not be executed');
         });
     }
-    
+
     /**
      * Tests synchronized() does work if the majority of servers is up.
      *
@@ -100,23 +101,24 @@ class RedisMutexTest extends TestCase
     {
         $mutex = $this->buildRedisMutex($count);
         $mutex->expects($this->exactly($count))
-            ->method("evalScript")
+            ->method('evalScript')
             ->willReturn(true);
-        
+
         $i = 0;
         $mutex->expects($this->exactly($count))
-            ->method("add")
+            ->method('add')
             ->willReturnCallback(
                 function () use (&$i, $available): bool {
                     if ($i < $available) {
                         $i++;
+
                         return true;
                     } else {
                         throw new LockAcquireException();
                     }
                 }
             );
-        
+
         $mutex->synchronized(function () {
         });
     }
@@ -134,19 +136,20 @@ class RedisMutexTest extends TestCase
     public function testAcquireTooFewKeys($count, $available)
     {
         $mutex = $this->buildRedisMutex($count);
-        
+
         $i = 0;
         $mutex->expects($this->any())
-            ->method("add")
+            ->method('add')
             ->willReturnCallback(
                 function () use (&$i, $available): bool {
                     $i++;
+
                     return $i <= $available;
                 }
             );
-        
+
         $mutex->synchronized(function (): void {
-            $this->fail("Code should not be executed");
+            $this->fail('Code should not be executed');
         });
     }
 
@@ -163,16 +166,17 @@ class RedisMutexTest extends TestCase
     public function testTimingOut(int $count, int $timeout, int $delay)
     {
         $mutex = $this->buildRedisMutex($count, $timeout);
-        
+
         $mutex->expects($this->exactly($count))
-            ->method("add")
+            ->method('add')
             ->willReturnCallback(function () use ($delay): bool {
                 usleep($delay);
+
                 return true;
             });
-        
+
         $mutex->synchronized(function () {
-            $this->fail("Code should not be executed");
+            $this->fail('Code should not be executed');
         });
     }
 
@@ -189,7 +193,7 @@ class RedisMutexTest extends TestCase
             [2, 1, 1001000],
         ];
     }
-    
+
     /**
      * Tests synchronized() works if the majority of keys was acquired.
      *
@@ -202,19 +206,20 @@ class RedisMutexTest extends TestCase
     {
         $mutex = $this->buildRedisMutex($count);
         $mutex->expects($this->exactly($count))
-            ->method("evalScript")
+            ->method('evalScript')
             ->willReturn(true);
-        
+
         $i = 0;
         $mutex->expects($this->exactly($count))
-            ->method("add")
+            ->method('add')
             ->willReturnCallback(
                 function () use (&$i, $available): int {
                     $i++;
+
                     return $i <= $available;
                 }
             );
-        
+
         $mutex->synchronized(function (): void {
         });
     }
@@ -232,23 +237,24 @@ class RedisMutexTest extends TestCase
     {
         $mutex = $this->buildRedisMutex($count);
         $mutex->expects($this->exactly($count))
-            ->method("add")
+            ->method('add')
             ->willReturn(true);
-        
+
         $i = 0;
         $mutex->expects($this->exactly($count))
-            ->method("evalScript")
+            ->method('evalScript')
             ->willReturnCallback(
                 function () use (&$i, $available): bool {
                     if ($i < $available) {
                         $i++;
+
                         return true;
                     } else {
                         throw new LockReleaseException();
                     }
                 }
             );
-        
+
         $mutex->synchronized(function (): void {
         });
     }
@@ -266,23 +272,24 @@ class RedisMutexTest extends TestCase
     {
         $mutex = $this->buildRedisMutex($count);
         $mutex->expects($this->exactly($count))
-            ->method("add")
+            ->method('add')
             ->willReturn(true);
-        
+
         $i = 0;
         $mutex->expects($this->exactly($count))
-            ->method("evalScript")
+            ->method('evalScript')
             ->willReturnCallback(
                 function () use (&$i, $available): bool {
                     $i++;
+
                     return $i <= $available;
                 }
             );
-        
+
         $mutex->synchronized(function (): void {
         });
     }
-    
+
     /**
      * Provides test cases with too few.
      *
@@ -302,7 +309,7 @@ class RedisMutexTest extends TestCase
             [4, 2],
         ];
     }
-    
+
     /**
      * Provides test cases with enough.
      *

--- a/tests/mutex/SpinlockMutexTest.php
+++ b/tests/mutex/SpinlockMutexTest.php
@@ -80,7 +80,7 @@ class SpinlockMutexTest extends TestCase
         $this->expectException(ExecutionOutsideLockException::class);
         $this->expectExceptionMessageRegExp(
             '/The code executed for \d+\.\d+ seconds. But the timeout is 1 ' .
-            'seconds. The last \d+\.\d+ seconds were executed outside the lock./'
+            'seconds. The last \d+\.\d+ seconds were executed outside of the lock./'
         );
 
         $mutex->synchronized(function () {

--- a/tests/mutex/SpinlockMutexTest.php
+++ b/tests/mutex/SpinlockMutexTest.php
@@ -19,20 +19,20 @@ use PHPUnit\Framework\TestCase;
 class SpinlockMutexTest extends TestCase
 {
     use PHPMock;
-    
+
     protected function setUp()
     {
         parent::setUp();
-        
+
         $builder = new SleepEnvironmentBuilder();
         $builder->addNamespace(__NAMESPACE__);
         $builder->addNamespace('malkusch\lock\util');
         $sleep = $builder->build();
         $sleep->enable();
-        
+
         $this->registerForTearDown($sleep);
     }
-    
+
     /**
      * Tests failing to acquire the lock.
      *
@@ -40,14 +40,14 @@ class SpinlockMutexTest extends TestCase
      */
     public function testFailAcquireLock()
     {
-        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ["test"]);
-        $mutex->expects($this->any())->method("acquire")->willThrowException(new LockAcquireException());
+        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ['test']);
+        $mutex->expects($this->any())->method('acquire')->willThrowException(new LockAcquireException());
 
         $mutex->synchronized(function () {
-            $this->fail("execution is not expected");
+            $this->fail('execution is not expected');
         });
     }
-    
+
     /**
      * Tests failing to acquire the lock due to a timeout.
      *
@@ -56,16 +56,16 @@ class SpinlockMutexTest extends TestCase
      */
     public function testAcquireTimesOut()
     {
-        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ["test"]);
+        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ['test']);
         $mutex->expects($this->atLeastOnce())
-            ->method("acquire")
+            ->method('acquire')
             ->willReturn(false);
 
         $mutex->synchronized(function () {
-            $this->fail("execution is not expected");
+            $this->fail('execution is not expected');
         });
     }
-    
+
     /**
      * Tests executing code which exceeds the timeout fails.
      *
@@ -73,9 +73,9 @@ class SpinlockMutexTest extends TestCase
     public function testExecuteTooLong()
     {
         /** @var SpinlockMutex|\PHPUnit\Framework\MockObject\MockObject $mutex */
-        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ["test", 1]);
-        $mutex->expects($this->any())->method("acquire")->willReturn(true);
-        $mutex->expects($this->any())->method("release")->willReturn(true);
+        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ['test', 1]);
+        $mutex->expects($this->any())->method('acquire')->willReturn(true);
+        $mutex->expects($this->any())->method('release')->willReturn(true);
 
         $this->expectException(ExecutionOutsideLockException::class);
         $this->expectExceptionMessageRegExp(
@@ -87,16 +87,16 @@ class SpinlockMutexTest extends TestCase
             usleep(1e6 + 1);
         });
     }
-    
+
     /**
      * Tests executing code which barely doesn't hit the timeout.
      *
      */
     public function testExecuteBarelySucceeds()
     {
-        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ["test", 1]);
-        $mutex->expects($this->any())->method("acquire")->willReturn(true);
-        $mutex->expects($this->once())->method("release")->willReturn(true);
+        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ['test', 1]);
+        $mutex->expects($this->any())->method('acquire')->willReturn(true);
+        $mutex->expects($this->once())->method('release')->willReturn(true);
 
         $mutex->synchronized(function () {
             usleep(999999);
@@ -110,28 +110,28 @@ class SpinlockMutexTest extends TestCase
      */
     public function testFailReleasingLock()
     {
-        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ["test"]);
-        $mutex->expects($this->any())->method("acquire")->willReturn(true);
-        $mutex->expects($this->any())->method("release")->willReturn(false);
-        
+        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ['test']);
+        $mutex->expects($this->any())->method('acquire')->willReturn(true);
+        $mutex->expects($this->any())->method('release')->willReturn(false);
+
         $mutex->synchronized(function () {
         });
     }
-    
+
     /**
      * Tests executing exactly unitl the timeout will leave the key one more second.
      *
      */
     public function testExecuteTimeoutLeavesOneSecondForKeyToExpire()
     {
-        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ["test", 3]);
+        $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ['test', 3]);
         $mutex->expects($this->once())
-            ->method("acquire")
+            ->method('acquire')
             ->with($this->anything(), 4)
             ->willReturn(true);
-        
-        $mutex->expects($this->once())->method("release")->willReturn(true);
-        
+
+        $mutex->expects($this->once())->method('release')->willReturn(true);
+
         $mutex->synchronized(function () {
             usleep(2999999);
         });

--- a/tests/util/DoubleCheckedLockingTest.php
+++ b/tests/util/DoubleCheckedLockingTest.php
@@ -20,11 +20,11 @@ class DoubleCheckedLockingTest extends TestCase
      * @var Mutex|MockObject The Mutex mock.
      */
     private $mutex;
-    
+
     protected function setUp()
     {
         parent::setUp();
-        
+
         $this->mutex = $this->createMock(Mutex::class);
     }
 
@@ -33,7 +33,7 @@ class DoubleCheckedLockingTest extends TestCase
      */
     public function testCheckFailsAcquiresNoLock()
     {
-        $this->mutex->expects($this->never())->method("synchronized");
+        $this->mutex->expects($this->never())->method('synchronized');
 
         $checkedLocking = new DoubleCheckedLocking($this->mutex, function (): bool {
             return false;
@@ -46,18 +46,18 @@ class DoubleCheckedLockingTest extends TestCase
         // Failed check should return false.
         $this->assertFalse($result);
     }
-    
+
     /**
      * Tests that the check and execution are in the same lock.
      *
      */
     public function testLockedCheckAndExecution()
     {
-        $lock  = 0;
+        $lock = 0;
         $check = 0;
-        
+
         $this->mutex->expects($this->once())
-                ->method("synchronized")
+                ->method('synchronized')
                 ->willReturnCallback(function (callable $block) use (&$lock) {
                     $lock++;
                     $result = $block();
@@ -86,7 +86,7 @@ class DoubleCheckedLockingTest extends TestCase
         // Synchronized code should return a test string.
         $this->assertSame('test', $result);
     }
-    
+
     /**
      * Tests that the code is not executed if the first or second check fails.
      *
@@ -96,7 +96,7 @@ class DoubleCheckedLockingTest extends TestCase
     public function testCodeNotExecuted(callable $check)
     {
         $this->mutex->expects($this->any())
-                ->method("synchronized")
+                ->method('synchronized')
                 ->willReturnCallback(function (callable $block) {
                     return $block();
                 });
@@ -109,7 +109,7 @@ class DoubleCheckedLockingTest extends TestCase
         // Each failed check should return false.
         $this->assertFalse($result);
     }
-    
+
     /**
      * Returns checks for testCodeNotExecuted().
      *
@@ -118,6 +118,7 @@ class DoubleCheckedLockingTest extends TestCase
     public function provideTestCodeNotExecuted()
     {
         $checkCounter = 0;
+
         return [
             [function (): bool {
                 return false;
@@ -126,18 +127,19 @@ class DoubleCheckedLockingTest extends TestCase
             [function () use (&$checkCounter): bool {
                 $result = $checkCounter == 0;
                 $checkCounter++;
+
                 return $result;
             }],
         ];
     }
-    
+
     /**
      * Tests that the code executed if the checks are true.
      */
     public function testCodeExecuted()
     {
         $this->mutex->expects($this->once())
-                ->method("synchronized")
+                ->method('synchronized')
                 ->willReturnCallback(function (callable $block) {
                     return $block();
                 });

--- a/tests/util/LoopTest.php
+++ b/tests/util/LoopTest.php
@@ -17,16 +17,16 @@ use PHPUnit\Framework\TestCase;
 class LoopTest extends TestCase
 {
     use PHPMock;
-    
+
     protected function setUp()
     {
         parent::setUp();
-        
+
         $builder = new SleepEnvironmentBuilder();
         $builder->addNamespace(__NAMESPACE__);
         $sleep = $builder->build();
         $sleep->enable();
-        
+
         $this->registerForTearDown($sleep);
     }
 
@@ -38,7 +38,7 @@ class LoopTest extends TestCase
     {
         new Loop(0);
     }
-    
+
     /**
      * Tests execution within the timeout.
      */
@@ -52,7 +52,7 @@ class LoopTest extends TestCase
             $loop->end();
         });
     }
-    
+
     /**
      * Tests exceeding the execution timeout.
      *
@@ -67,7 +67,7 @@ class LoopTest extends TestCase
             $loop->end();
         });
     }
-    
+
     /**
      * Tests exceeding the execution timeout without calling end().
      *
@@ -100,7 +100,7 @@ class LoopTest extends TestCase
      */
     public function testEnd()
     {
-        $i    = 0;
+        $i = 0;
         $loop = new Loop();
         $loop->execute(function () use ($loop, &$i) {
             $i++;
@@ -114,7 +114,7 @@ class LoopTest extends TestCase
      */
     public function testIteration()
     {
-        $i    = 0;
+        $i = 0;
         $loop = new Loop();
         $loop->execute(function () use ($loop, &$i): void {
             $i++;


### PR DESCRIPTION
- Added php-cs-fixer with a configurable ruleset for code format.
- Added `declare(strict_types=1);` to all files.
- Fixed a missing log placeholder value 2ca1e30.
- Added many missing docblock comments.
- Improved exception inheritance.